### PR TITLE
Implement setup parameter in model

### DIFF
--- a/packages/moqtail-core/src/message/client_setup.rs
+++ b/packages/moqtail-core/src/message/client_setup.rs
@@ -1,15 +1,40 @@
-use crate::coding::{Decode, Encode};
+use crate::coding::{Decode, Encode, VarInt};
+use bytes::{Buf, BufMut};
+use crate::model::SetupParameter;
 
-pub struct ClientSetup {}
+#[derive(Debug, Clone)]
+pub struct ClientSetup {
+    pub versions: Vec<VarInt>,
+    pub parameters: Vec<SetupParameter>,
+}
 
 impl Encode for ClientSetup {
-    fn encode<B: bytes::BufMut>(&self, _buf: &mut B) {
-        todo!()
+    fn encode<B: BufMut>(&self, buf: &mut B) {
+        VarInt(self.versions.len() as u64).encode(buf);
+        for v in &self.versions {
+            v.encode(buf);
+        }
+        VarInt(self.parameters.len() as u64).encode(buf);
+        for p in &self.parameters {
+            p.encode(buf);
+        }
     }
 }
 
 impl<'a> Decode<'a> for ClientSetup {
-    fn decode<B: bytes::Buf>(_buf: &mut B) -> Result<Self, crate::coding::Error> {
-        todo!()
+    fn decode<B: Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
+        let num_versions = VarInt::decode(buf)?.into_inner() as usize;
+        let mut versions = Vec::with_capacity(num_versions);
+        for _ in 0..num_versions {
+            versions.push(VarInt::decode(buf)?);
+        }
+
+        let num_params = VarInt::decode(buf)?.into_inner() as usize;
+        let mut parameters = Vec::new();
+        for _ in 0..num_params {
+            parameters.push(SetupParameter::decode(buf)?);
+        }
+
+        Ok(ClientSetup { versions, parameters })
     }
 }

--- a/packages/moqtail-core/src/message/server_setup.rs
+++ b/packages/moqtail-core/src/message/server_setup.rs
@@ -1,15 +1,36 @@
-use crate::coding::{Decode, Encode};
+use crate::coding::{Decode, Encode, VarInt};
+use bytes::{Buf, BufMut};
+use crate::model::SetupParameter;
 
-pub struct ServerSetup {}
+#[derive(Debug, Clone)]
+pub struct ServerSetup {
+    pub selected_version: VarInt,
+    pub parameters: Vec<SetupParameter>,
+}
 
 impl Encode for ServerSetup {
-    fn encode<B: bytes::BufMut>(&self, _buf: &mut B) {
-        todo!()
+    fn encode<B: BufMut>(&self, buf: &mut B) {
+        self.selected_version.encode(buf);
+        VarInt(self.parameters.len() as u64).encode(buf);
+        for p in &self.parameters {
+            p.encode(buf);
+        }
     }
 }
 
 impl<'a> Decode<'a> for ServerSetup {
-    fn decode<B: bytes::Buf>(_buf: &mut B) -> Result<Self, crate::coding::Error> {
-        todo!()
+    fn decode<B: Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
+        let selected_version = VarInt::decode(buf)?;
+
+        let num_params = VarInt::decode(buf)?.into_inner() as usize;
+        let mut parameters = Vec::new();
+        for _ in 0..num_params {
+            parameters.push(SetupParameter::decode(buf)?);
+        }
+
+        Ok(ServerSetup {
+            selected_version,
+            parameters,
+        })
     }
 }

--- a/packages/moqtail-core/src/model.rs
+++ b/packages/moqtail-core/src/model.rs
@@ -25,3 +25,66 @@ pub struct Object {
     pub publisher_priority: u8,
     pub payload: bytes::Bytes,
 }
+
+#[derive(Debug, Clone)]
+pub enum SetupParameter {
+    Path(String),
+    MaxSubscribeId(VarInt),
+    Unknown { ty: VarInt, value: bytes::Bytes },
+}
+
+impl crate::coding::Encode for SetupParameter {
+    fn encode<B: bytes::BufMut>(&self, buf: &mut B) {
+        match self {
+            SetupParameter::Path(path) => {
+                VarInt(1).encode(buf);
+                VarInt(path.as_bytes().len() as u64).encode(buf);
+                buf.put_slice(path.as_bytes());
+            }
+            SetupParameter::MaxSubscribeId(id) => {
+                VarInt(2).encode(buf);
+                let mut tmp = bytes::BytesMut::new();
+                id.encode(&mut tmp);
+                VarInt(tmp.len() as u64).encode(buf);
+                buf.put_slice(&tmp);
+            }
+            SetupParameter::Unknown { ty, value } => {
+                ty.encode(buf);
+                VarInt(value.len() as u64).encode(buf);
+                buf.put_slice(value);
+            }
+        }
+    }
+}
+
+impl<'a> crate::coding::Decode<'a> for SetupParameter {
+    fn decode<B: bytes::Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
+        let ty = VarInt::decode(buf)?;
+        match ty.into_inner() {
+            0x01 => {
+                let len = VarInt::decode(buf)?.into_inner() as usize;
+                if buf.remaining() < len {
+                    return Err(crate::coding::Error::UnexpectedEnd);
+                }
+                let bytes = buf.copy_to_bytes(len);
+                let path = std::str::from_utf8(&bytes)
+                    .map_err(|_| crate::coding::Error::UnexpectedEnd)?
+                    .to_string();
+                Ok(SetupParameter::Path(path))
+            }
+            0x02 => {
+                let _len = VarInt::decode(buf)?;
+                let val = VarInt::decode(buf)?;
+                Ok(SetupParameter::MaxSubscribeId(val))
+            }
+            _ => {
+                let len = VarInt::decode(buf)?.into_inner() as usize;
+                if buf.remaining() < len {
+                    return Err(crate::coding::Error::UnexpectedEnd);
+                }
+                let bytes = buf.copy_to_bytes(len);
+                Ok(SetupParameter::Unknown { ty, value: bytes })
+            }
+        }
+    }
+}

--- a/packages/moqtail-core/src/session.rs
+++ b/packages/moqtail-core/src/session.rs
@@ -1,4 +1,4 @@
-use crate::coding::{Decode, Encode};
+use crate::coding::{Decode, Encode, VarInt};
 use crate::message::{ClientSetup, ControlMessage, Subscribe};
 use crate::model::*;
 use async_trait::async_trait;
@@ -15,8 +15,8 @@ impl<T: MoqConnection> Session<T> {
         let mut control_stream = conn.open_bi().await?;
 
         let setup = ClientSetup {
-        //    supported_versions: vec![VarInt(1)],
-        //    ..Default::default()
+            versions: vec![VarInt(1)],
+            parameters: Vec::new(),
         };
         let mut buf = bytes::BytesMut::new();
         ControlMessage::ClientSetup(setup).encode(&mut buf);


### PR DESCRIPTION
## Summary
- move `SetupParameter` enum into `model.rs`
- reference the new location from `ClientSetup` and `ServerSetup`
- remove obsolete module

## Testing
- `cargo check --workspace`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_6857802c229c832987e52ec63163a013