### PR TITLE
Implement MaxSubscribeId encode/decode

### DIFF
--- a/packages/moqtail-core/src/message/max_subscribe_id.rs
+++ b/packages/moqtail-core/src/message/max_subscribe_id.rs
@@ -1,15 +1,20 @@
-use crate::coding::{Decode, Encode};
+use crate::coding::{Decode, Encode, VarInt};
+use bytes::{Buf, BufMut};
 
-pub struct MaxSubscribeId {}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MaxSubscribeId {
+    pub subscribe_id: VarInt,
+}
 
 impl Encode for MaxSubscribeId {
-    fn encode<B: bytes::BufMut>(&self, _buf: &mut B) {
-        todo!()
+    fn encode<B: BufMut>(&self, buf: &mut B) {
+        self.subscribe_id.encode(buf);
     }
 }
 
 impl<'a> Decode<'a> for MaxSubscribeId {
-    fn decode<B: bytes::Buf>(_buf: &mut B) -> Result<Self, crate::coding::Error> {
-        todo!()
+    fn decode<B: Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
+        let subscribe_id = VarInt::decode(buf)?;
+        Ok(Self { subscribe_id })
     }
 }


### PR DESCRIPTION
## Summary
- define fields for `MaxSubscribeId` message
- implement encoding/decoding logic

## Testing
- `cargo build -p moqtail-core --quiet`
- `cargo test -p moqtail-core --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6857832f1ec88329a72500979a10ea7e