### PR TITLE
Implement Subscribe encode/decode

### DIFF
--- a/packages/moqtail-core/src/message/subscribe.rs
+++ b/packages/moqtail-core/src/message/subscribe.rs
@@ -1,15 +1,132 @@
-use crate::coding::{Decode, Encode};
+use crate::coding::{Decode, Encode, VarInt};
+use crate::model::{GroupOrder, Parameter, SubscribeFilter, TrackAlias, TrackName, TrackNamespace};
+use bytes::{Buf, BufMut};
 
-pub struct Subscribe {}
+#[derive(Debug, Clone)]
+pub struct Subscribe {
+    pub subscribe_id: VarInt,
+    pub track_alias: TrackAlias,
+    pub track_namespace: TrackNamespace,
+    pub track_name: TrackName,
+    pub subscriber_priority: u8,
+    pub group_order: GroupOrder,
+    pub filter_type: SubscribeFilter,
+    pub start_group: Option<VarInt>,
+    pub start_object: Option<VarInt>,
+    pub end_group: Option<VarInt>,
+    pub parameters: Vec<Parameter>,
+}
 
 impl Encode for Subscribe {
-    fn encode<B: bytes::BufMut>(&self, _buf: &mut B) {
-        todo!()
+    fn encode<B: BufMut>(&self, buf: &mut B) {
+        self.subscribe_id.encode(buf);
+        self.track_alias.encode(buf);
+        VarInt(self.track_namespace.len() as u64).encode(buf);
+        for ns in &self.track_namespace {
+            VarInt(ns.as_bytes().len() as u64).encode(buf);
+            buf.put_slice(ns.as_bytes());
+        }
+        VarInt(self.track_name.as_bytes().len() as u64).encode(buf);
+        buf.put_slice(self.track_name.as_bytes());
+        buf.put_u8(self.subscriber_priority);
+        buf.put_u8(self.group_order.into());
+        VarInt::from(self.filter_type).encode(buf);
+        if matches!(self.filter_type, SubscribeFilter::AbsoluteStart | SubscribeFilter::AbsoluteRange) {
+            if let Some(g) = self.start_group {
+                g.encode(buf);
+            } else {
+                VarInt(0).encode(buf);
+            }
+            if let Some(o) = self.start_object {
+                o.encode(buf);
+            } else {
+                VarInt(0).encode(buf);
+            }
+        }
+        if matches!(self.filter_type, SubscribeFilter::AbsoluteRange) {
+            if let Some(g) = self.end_group {
+                g.encode(buf);
+            } else {
+                VarInt(0).encode(buf);
+            }
+        }
+        VarInt(self.parameters.len() as u64).encode(buf);
+        for p in &self.parameters {
+            p.encode(buf);
+        }
     }
 }
 
 impl<'a> Decode<'a> for Subscribe {
-    fn decode<B: bytes::Buf>(_buf: &mut B) -> Result<Self, crate::coding::Error> {
-        todo!()
+    fn decode<B: Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
+        let subscribe_id = VarInt::decode(buf)?;
+        let track_alias = VarInt::decode(buf)?;
+
+        let namespace_len = VarInt::decode(buf)?.into_inner() as usize;
+        let mut track_namespace = Vec::with_capacity(namespace_len);
+        for _ in 0..namespace_len {
+            let len = VarInt::decode(buf)?.into_inner() as usize;
+            if buf.remaining() < len {
+                return Err(crate::coding::Error::UnexpectedEnd);
+            }
+            let bytes = buf.copy_to_bytes(len);
+            let s = std::str::from_utf8(&bytes)
+                .map_err(|_| crate::coding::Error::UnexpectedEnd)?
+                .to_string();
+            track_namespace.push(s);
+        }
+
+        let name_len = VarInt::decode(buf)?.into_inner() as usize;
+        if buf.remaining() < name_len {
+            return Err(crate::coding::Error::UnexpectedEnd);
+        }
+        let bytes = buf.copy_to_bytes(name_len);
+        let track_name = std::str::from_utf8(&bytes)
+            .map_err(|_| crate::coding::Error::UnexpectedEnd)?
+            .to_string();
+
+        if !buf.has_remaining() {
+            return Err(crate::coding::Error::UnexpectedEnd);
+        }
+        let subscriber_priority = buf.get_u8();
+
+        if !buf.has_remaining() {
+            return Err(crate::coding::Error::UnexpectedEnd);
+        }
+        let group_order = GroupOrder::from(buf.get_u8());
+
+        let filter_type = SubscribeFilter::from(VarInt::decode(buf)?);
+
+        let (start_group, start_object) = if matches!(filter_type, SubscribeFilter::AbsoluteStart | SubscribeFilter::AbsoluteRange) {
+            (Some(VarInt::decode(buf)?), Some(VarInt::decode(buf)?))
+        } else {
+            (None, None)
+        };
+
+        let end_group = if matches!(filter_type, SubscribeFilter::AbsoluteRange) {
+            Some(VarInt::decode(buf)?)
+        } else {
+            None
+        };
+
+        let num_params = VarInt::decode(buf)?.into_inner() as usize;
+        let mut parameters = Vec::with_capacity(num_params);
+        for _ in 0..num_params {
+            parameters.push(Parameter::decode(buf)?);
+        }
+
+        Ok(Subscribe {
+            subscribe_id,
+            track_alias,
+            track_namespace,
+            track_name,
+            subscriber_priority,
+            group_order,
+            filter_type,
+            start_group,
+            start_object,
+            end_group,
+            parameters,
+        })
     }
 }

--- a/packages/moqtail-core/src/model.rs
+++ b/packages/moqtail-core/src/model.rs
@@ -88,3 +88,125 @@ impl<'a> crate::coding::Decode<'a> for SetupParameter {
         }
     }
 }
+
+#[derive(Debug, Clone)]
+pub enum Parameter {
+    AuthorizationInfo(String),
+    DeliveryTimeout(VarInt),
+    MaxCacheDuration(VarInt),
+    Unknown { ty: VarInt, value: bytes::Bytes },
+}
+
+impl crate::coding::Encode for Parameter {
+    fn encode<B: bytes::BufMut>(&self, buf: &mut B) {
+        match self {
+            Parameter::AuthorizationInfo(info) => {
+                VarInt(0x02).encode(buf);
+                VarInt(info.as_bytes().len() as u64).encode(buf);
+                buf.put_slice(info.as_bytes());
+            }
+            Parameter::DeliveryTimeout(v) => {
+                VarInt(0x03).encode(buf);
+                let mut tmp = bytes::BytesMut::new();
+                v.encode(&mut tmp);
+                VarInt(tmp.len() as u64).encode(buf);
+                buf.put_slice(&tmp);
+            }
+            Parameter::MaxCacheDuration(v) => {
+                VarInt(0x04).encode(buf);
+                let mut tmp = bytes::BytesMut::new();
+                v.encode(&mut tmp);
+                VarInt(tmp.len() as u64).encode(buf);
+                buf.put_slice(&tmp);
+            }
+            Parameter::Unknown { ty, value } => {
+                ty.encode(buf);
+                VarInt(value.len() as u64).encode(buf);
+                buf.put_slice(value);
+            }
+        }
+    }
+}
+
+impl<'a> crate::coding::Decode<'a> for Parameter {
+    fn decode<B: bytes::Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
+        let ty = VarInt::decode(buf)?;
+        match ty.into_inner() {
+            0x02 => {
+                let len = VarInt::decode(buf)?.into_inner() as usize;
+                if buf.remaining() < len {
+                    return Err(crate::coding::Error::UnexpectedEnd);
+                }
+                let bytes = buf.copy_to_bytes(len);
+                let info = std::str::from_utf8(&bytes)
+                    .map_err(|_| crate::coding::Error::UnexpectedEnd)?
+                    .to_string();
+                Ok(Parameter::AuthorizationInfo(info))
+            }
+            0x03 => {
+                let _len = VarInt::decode(buf)?;
+                let v = VarInt::decode(buf)?;
+                Ok(Parameter::DeliveryTimeout(v))
+            }
+            0x04 => {
+                let _len = VarInt::decode(buf)?;
+                let v = VarInt::decode(buf)?;
+                Ok(Parameter::MaxCacheDuration(v))
+            }
+            _ => {
+                let len = VarInt::decode(buf)?.into_inner() as usize;
+                if buf.remaining() < len {
+                    return Err(crate::coding::Error::UnexpectedEnd);
+                }
+                let bytes = buf.copy_to_bytes(len);
+                Ok(Parameter::Unknown { ty, value: bytes })
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GroupOrder {
+    Publisher = 0x0,
+    Ascending = 0x1,
+    Descending = 0x2,
+}
+
+impl From<u8> for GroupOrder {
+    fn from(v: u8) -> Self {
+        match v {
+            0x1 => GroupOrder::Ascending,
+            0x2 => GroupOrder::Descending,
+            _ => GroupOrder::Publisher,
+        }
+    }
+}
+
+impl From<GroupOrder> for u8 {
+    fn from(v: GroupOrder) -> Self {
+        v as u8
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubscribeFilter {
+    LatestObject = 0x2,
+    AbsoluteStart = 0x3,
+    AbsoluteRange = 0x4,
+}
+
+impl From<VarInt> for SubscribeFilter {
+    fn from(v: VarInt) -> Self {
+        match v.into_inner() {
+            0x3 => SubscribeFilter::AbsoluteStart,
+            0x4 => SubscribeFilter::AbsoluteRange,
+            _ => SubscribeFilter::LatestObject,
+        }
+    }
+}
+
+impl From<SubscribeFilter> for VarInt {
+    fn from(f: SubscribeFilter) -> Self {
+        VarInt(f as u64)
+    }
+}

--- a/packages/moqtail-core/src/session.rs
+++ b/packages/moqtail-core/src/session.rs
@@ -54,10 +54,17 @@ impl<T: MoqConnection> Session<T> {
         self.next_subscribe_id += 1;
 
         let msg = Subscribe {
-        //    subscribe_id: VarInt(sub_id),
-        //    track_alias: VarInt(sub_id),
-        //    track_namespace: namespace,
-        //    track_name: name,
+            subscribe_id: VarInt(sub_id),
+            track_alias: VarInt(sub_id),
+            track_namespace: namespace,
+            track_name: name,
+            subscriber_priority: 0,
+            group_order: GroupOrder::Publisher,
+            filter_type: SubscribeFilter::LatestObject,
+            start_group: None,
+            start_object: None,
+            end_group: None,
+            parameters: Vec::new(),
         };
 
         let mut buf = bytes::BytesMut::new();


### PR DESCRIPTION
## Summary
- add `Parameter`, `GroupOrder`, and `SubscribeFilter` types
- implement `Subscribe` struct with encode/decode logic
- update `Session` to create `Subscribe` with new fields

## Testing
- `cargo check -p moqtail-core`
- `cargo test -p moqtail-core`


------
https://chatgpt.com/codex/tasks/task_e_6857839f059883299209e5d973c26e24