### PR TITLE
Implement SubscribeOk

### DIFF
--- a/packages/moqtail-core/src/message/subscribe_ok.rs
+++ b/packages/moqtail-core/src/message/subscribe_ok.rs
@@ -1,6 +1,6 @@
 use crate::coding::{Decode, Encode, VarInt};
 use bytes::{Buf, BufMut};
-use crate::model::Parameter;
+use crate::model::SubscribeParameter;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubscribeOk {
@@ -10,7 +10,7 @@ pub struct SubscribeOk {
     pub content_exists: u8,
     pub largest_group_id: Option<VarInt>,
     pub largest_object_id: Option<VarInt>,
-    pub parameters: Vec<Parameter>,
+    pub parameters: Vec<SubscribeParameter>,
 }
 
 impl Encode for SubscribeOk {
@@ -58,7 +58,7 @@ impl<'a> Decode<'a> for SubscribeOk {
         let num_params = VarInt::decode(buf)?.into_inner() as usize;
         let mut parameters = Vec::new();
         for _ in 0..num_params {
-            parameters.push(Parameter::decode(buf)?);
+            parameters.push(SubscribeParameter::decode(buf)?);
         }
 
         Ok(SubscribeOk {
@@ -105,7 +105,7 @@ mod tests {
             content_exists: 1,
             largest_group_id: Some(VarInt(5)),
             largest_object_id: Some(VarInt(7)),
-            parameters: vec![Parameter::DeliveryTimeout(VarInt(3))],
+            parameters: vec![SubscribeParameter::DeliveryTimeout(VarInt(3))],
         };
         let mut buf = bytes::BytesMut::new();
         msg.encode(&mut buf);

--- a/packages/moqtail-core/src/message/subscribe_ok.rs
+++ b/packages/moqtail-core/src/message/subscribe_ok.rs
@@ -1,15 +1,117 @@
-use crate::coding::{Decode, Encode};
+use crate::coding::{Decode, Encode, VarInt};
+use bytes::{Buf, BufMut};
+use crate::model::Parameter;
 
-pub struct SubscribeOk {}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubscribeOk {
+    pub subscribe_id: VarInt,
+    pub expires: VarInt,
+    pub group_order: u8,
+    pub content_exists: u8,
+    pub largest_group_id: Option<VarInt>,
+    pub largest_object_id: Option<VarInt>,
+    pub parameters: Vec<Parameter>,
+}
 
 impl Encode for SubscribeOk {
-    fn encode<B: bytes::BufMut>(&self, _buf: &mut B) {
-        todo!()
+    fn encode<B: BufMut>(&self, buf: &mut B) {
+        self.subscribe_id.encode(buf);
+        self.expires.encode(buf);
+        buf.put_u8(self.group_order);
+        buf.put_u8(self.content_exists);
+        if self.content_exists == 1 {
+            if let Some(gid) = &self.largest_group_id {
+                gid.encode(buf);
+            }
+            if let Some(oid) = &self.largest_object_id {
+                oid.encode(buf);
+            }
+        }
+        VarInt(self.parameters.len() as u64).encode(buf);
+        for p in &self.parameters {
+            p.encode(buf);
+        }
     }
 }
 
 impl<'a> Decode<'a> for SubscribeOk {
-    fn decode<B: bytes::Buf>(_buf: &mut B) -> Result<Self, crate::coding::Error> {
-        todo!()
+    fn decode<B: Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
+        let subscribe_id = VarInt::decode(buf)?;
+        let expires = VarInt::decode(buf)?;
+        if !buf.has_remaining() {
+            return Err(crate::coding::Error::UnexpectedEnd);
+        }
+        let group_order = buf.get_u8();
+        if !buf.has_remaining() {
+            return Err(crate::coding::Error::UnexpectedEnd);
+        }
+        let content_exists = buf.get_u8();
+
+        let (largest_group_id, largest_object_id) = if content_exists == 1 {
+            let gid = VarInt::decode(buf)?;
+            let oid = VarInt::decode(buf)?;
+            (Some(gid), Some(oid))
+        } else {
+            (None, None)
+        };
+
+        let num_params = VarInt::decode(buf)?.into_inner() as usize;
+        let mut parameters = Vec::new();
+        for _ in 0..num_params {
+            parameters.push(Parameter::decode(buf)?);
+        }
+
+        Ok(SubscribeOk {
+            subscribe_id,
+            expires,
+            group_order,
+            content_exists,
+            largest_group_id,
+            largest_object_id,
+            parameters,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_roundtrip_no_content() {
+        let msg = SubscribeOk {
+            subscribe_id: VarInt(1),
+            expires: VarInt(0),
+            group_order: 1,
+            content_exists: 0,
+            largest_group_id: None,
+            largest_object_id: None,
+            parameters: Vec::new(),
+        };
+        let mut buf = bytes::BytesMut::new();
+        msg.encode(&mut buf);
+
+        let mut bytes = buf.freeze();
+        let decoded = SubscribeOk::decode(&mut bytes).unwrap();
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn encode_decode_roundtrip_with_content() {
+        let msg = SubscribeOk {
+            subscribe_id: VarInt(2),
+            expires: VarInt(10),
+            group_order: 2,
+            content_exists: 1,
+            largest_group_id: Some(VarInt(5)),
+            largest_object_id: Some(VarInt(7)),
+            parameters: vec![Parameter::DeliveryTimeout(VarInt(3))],
+        };
+        let mut buf = bytes::BytesMut::new();
+        msg.encode(&mut buf);
+
+        let mut bytes = buf.freeze();
+        let decoded = SubscribeOk::decode(&mut bytes).unwrap();
+        assert_eq!(decoded, msg);
     }
 }

--- a/packages/moqtail-core/src/model.rs
+++ b/packages/moqtail-core/src/model.rs
@@ -88,3 +88,79 @@ impl<'a> crate::coding::Decode<'a> for SetupParameter {
         }
     }
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Parameter {
+    AuthorizationInfo(String),
+    DeliveryTimeout(VarInt),
+    MaxCacheDuration(VarInt),
+    Unknown { ty: VarInt, value: bytes::Bytes },
+}
+
+impl crate::coding::Encode for Parameter {
+    fn encode<B: bytes::BufMut>(&self, buf: &mut B) {
+        match self {
+            Parameter::AuthorizationInfo(info) => {
+                VarInt(0x02).encode(buf);
+                VarInt(info.as_bytes().len() as u64).encode(buf);
+                buf.put_slice(info.as_bytes());
+            }
+            Parameter::DeliveryTimeout(v) => {
+                VarInt(0x03).encode(buf);
+                let mut tmp = bytes::BytesMut::new();
+                v.encode(&mut tmp);
+                VarInt(tmp.len() as u64).encode(buf);
+                buf.put_slice(&tmp);
+            }
+            Parameter::MaxCacheDuration(v) => {
+                VarInt(0x04).encode(buf);
+                let mut tmp = bytes::BytesMut::new();
+                v.encode(&mut tmp);
+                VarInt(tmp.len() as u64).encode(buf);
+                buf.put_slice(&tmp);
+            }
+            Parameter::Unknown { ty, value } => {
+                ty.encode(buf);
+                VarInt(value.len() as u64).encode(buf);
+                buf.put_slice(value);
+            }
+        }
+    }
+}
+
+impl<'a> crate::coding::Decode<'a> for Parameter {
+    fn decode<B: bytes::Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
+        let ty = VarInt::decode(buf)?;
+        match ty.into_inner() {
+            0x02 => {
+                let len = VarInt::decode(buf)?.into_inner() as usize;
+                if buf.remaining() < len {
+                    return Err(crate::coding::Error::UnexpectedEnd);
+                }
+                let bytes = buf.copy_to_bytes(len);
+                let info = std::str::from_utf8(&bytes)
+                    .map_err(|_| crate::coding::Error::UnexpectedEnd)?
+                    .to_string();
+                Ok(Parameter::AuthorizationInfo(info))
+            }
+            0x03 => {
+                let _len = VarInt::decode(buf)?;
+                let val = VarInt::decode(buf)?;
+                Ok(Parameter::DeliveryTimeout(val))
+            }
+            0x04 => {
+                let _len = VarInt::decode(buf)?;
+                let val = VarInt::decode(buf)?;
+                Ok(Parameter::MaxCacheDuration(val))
+            }
+            _ => {
+                let len = VarInt::decode(buf)?.into_inner() as usize;
+                if buf.remaining() < len {
+                    return Err(crate::coding::Error::UnexpectedEnd);
+                }
+                let bytes = buf.copy_to_bytes(len);
+                Ok(Parameter::Unknown { ty, value: bytes })
+            }
+        }
+    }
+}

--- a/packages/moqtail-core/src/model.rs
+++ b/packages/moqtail-core/src/model.rs
@@ -90,36 +90,36 @@ impl<'a> crate::coding::Decode<'a> for SetupParameter {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Parameter {
+pub enum SubscribeParameter {
     AuthorizationInfo(String),
     DeliveryTimeout(VarInt),
     MaxCacheDuration(VarInt),
     Unknown { ty: VarInt, value: bytes::Bytes },
 }
 
-impl crate::coding::Encode for Parameter {
+impl crate::coding::Encode for SubscribeParameter {
     fn encode<B: bytes::BufMut>(&self, buf: &mut B) {
         match self {
-            Parameter::AuthorizationInfo(info) => {
+            SubscribeParameter::AuthorizationInfo(info) => {
                 VarInt(0x02).encode(buf);
                 VarInt(info.as_bytes().len() as u64).encode(buf);
                 buf.put_slice(info.as_bytes());
             }
-            Parameter::DeliveryTimeout(v) => {
+            SubscribeParameter::DeliveryTimeout(v) => {
                 VarInt(0x03).encode(buf);
                 let mut tmp = bytes::BytesMut::new();
                 v.encode(&mut tmp);
                 VarInt(tmp.len() as u64).encode(buf);
                 buf.put_slice(&tmp);
             }
-            Parameter::MaxCacheDuration(v) => {
+            SubscribeParameter::MaxCacheDuration(v) => {
                 VarInt(0x04).encode(buf);
                 let mut tmp = bytes::BytesMut::new();
                 v.encode(&mut tmp);
                 VarInt(tmp.len() as u64).encode(buf);
                 buf.put_slice(&tmp);
             }
-            Parameter::Unknown { ty, value } => {
+            SubscribeParameter::Unknown { ty, value } => {
                 ty.encode(buf);
                 VarInt(value.len() as u64).encode(buf);
                 buf.put_slice(value);
@@ -128,7 +128,7 @@ impl crate::coding::Encode for Parameter {
     }
 }
 
-impl<'a> crate::coding::Decode<'a> for Parameter {
+impl<'a> crate::coding::Decode<'a> for SubscribeParameter {
     fn decode<B: bytes::Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
         let ty = VarInt::decode(buf)?;
         match ty.into_inner() {
@@ -141,17 +141,17 @@ impl<'a> crate::coding::Decode<'a> for Parameter {
                 let info = std::str::from_utf8(&bytes)
                     .map_err(|_| crate::coding::Error::UnexpectedEnd)?
                     .to_string();
-                Ok(Parameter::AuthorizationInfo(info))
+                Ok(SubscribeParameter::AuthorizationInfo(info))
             }
             0x03 => {
                 let _len = VarInt::decode(buf)?;
                 let val = VarInt::decode(buf)?;
-                Ok(Parameter::DeliveryTimeout(val))
+                Ok(SubscribeParameter::DeliveryTimeout(val))
             }
             0x04 => {
                 let _len = VarInt::decode(buf)?;
                 let val = VarInt::decode(buf)?;
-                Ok(Parameter::MaxCacheDuration(val))
+                Ok(SubscribeParameter::MaxCacheDuration(val))
             }
             _ => {
                 let len = VarInt::decode(buf)?.into_inner() as usize;
@@ -159,7 +159,7 @@ impl<'a> crate::coding::Decode<'a> for Parameter {
                     return Err(crate::coding::Error::UnexpectedEnd);
                 }
                 let bytes = buf.copy_to_bytes(len);
-                Ok(Parameter::Unknown { ty, value: bytes })
+                Ok(SubscribeParameter::Unknown { ty, value: bytes })
             }
         }
     }


### PR DESCRIPTION
## Summary
- flesh out SubscribeOk message fields
- add Parameter type used by SubscribeOk
- implement Encode/Decode for Parameter and SubscribeOk
- provide unit tests for SubscribeOk

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6857842e3994832992bd924905728528