### PR TITLE
Implement FetchCancel

### DIFF
--- a/packages/moqtail-core/src/message/fetch_cancel.rs
+++ b/packages/moqtail-core/src/message/fetch_cancel.rs
@@ -1,15 +1,40 @@
-use crate::coding::{Decode, Encode};
+use crate::coding::{Decode, Encode, VarInt};
+use bytes::{Buf, BufMut};
 
-pub struct FetchCancel {}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FetchCancel {
+    pub subscribe_id: VarInt,
+}
 
 impl Encode for FetchCancel {
-    fn encode<B: bytes::BufMut>(&self, _buf: &mut B) {
-        todo!()
+    fn encode<B: BufMut>(&self, buf: &mut B) {
+        self.subscribe_id.encode(buf);
     }
 }
 
 impl<'a> Decode<'a> for FetchCancel {
-    fn decode<B: bytes::Buf>(_buf: &mut B) -> Result<Self, crate::coding::Error> {
-        todo!()
+    fn decode<B: Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
+        let subscribe_id = VarInt::decode(buf)?;
+        Ok(Self { subscribe_id })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let msg = FetchCancel {
+            subscribe_id: VarInt(10),
+        };
+
+        let mut buf = bytes::BytesMut::new();
+        msg.encode(&mut buf);
+
+        let mut bytes = buf.freeze();
+        let decoded = FetchCancel::decode(&mut bytes).unwrap();
+
+        assert_eq!(decoded, msg);
     }
 }


### PR DESCRIPTION
## Summary
- implement the FetchCancel message structure
- add encode/decode logic
- add roundtrip unit test

## Testing
- `cargo test -p moqtail-core --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68578761b5348329962202da4d2e294c