### PR TITLE
Implement SubscribeAnnouncesError

### DIFF
--- a/packages/moqtail-core/src/message/subscribe_announces_error.rs
+++ b/packages/moqtail-core/src/message/subscribe_announces_error.rs
@@ -1,15 +1,80 @@
-use crate::coding::{Decode, Encode};
+use crate::coding::{Decode, Encode, VarInt};
+use crate::model::TrackNamespace;
+use bytes::{Buf, BufMut};
 
-pub struct SubscribeAnnouncesError {}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubscribeAnnouncesError {
+    pub track_namespace_prefix: TrackNamespace,
+    pub error_code: VarInt,
+    pub reason_phrase: String,
+}
 
 impl Encode for SubscribeAnnouncesError {
-    fn encode<B: bytes::BufMut>(&self, _buf: &mut B) {
-        todo!()
+    fn encode<B: bytes::BufMut>(&self, buf: &mut B) {
+        VarInt(self.track_namespace_prefix.len() as u64).encode(buf);
+        for ns in &self.track_namespace_prefix {
+            VarInt(ns.as_bytes().len() as u64).encode(buf);
+            buf.put_slice(ns.as_bytes());
+        }
+        self.error_code.encode(buf);
+        VarInt(self.reason_phrase.as_bytes().len() as u64).encode(buf);
+        buf.put_slice(self.reason_phrase.as_bytes());
     }
 }
 
 impl<'a> Decode<'a> for SubscribeAnnouncesError {
-    fn decode<B: bytes::Buf>(_buf: &mut B) -> Result<Self, crate::coding::Error> {
-        todo!()
+    fn decode<B: bytes::Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
+        let namespace_len = VarInt::decode(buf)?.into_inner() as usize;
+        let mut track_namespace_prefix = Vec::with_capacity(namespace_len);
+        for _ in 0..namespace_len {
+            let len = VarInt::decode(buf)?.into_inner() as usize;
+            if buf.remaining() < len {
+                return Err(crate::coding::Error::UnexpectedEnd);
+            }
+            let bytes = buf.copy_to_bytes(len);
+            let s = std::str::from_utf8(&bytes)
+                .map_err(|_| crate::coding::Error::UnexpectedEnd)?
+                .to_string();
+            track_namespace_prefix.push(s);
+        }
+
+        let error_code = VarInt::decode(buf)?;
+
+        let len = VarInt::decode(buf)?.into_inner() as usize;
+        if buf.remaining() < len {
+            return Err(crate::coding::Error::UnexpectedEnd);
+        }
+        let bytes = buf.copy_to_bytes(len);
+        let reason_phrase = std::str::from_utf8(&bytes)
+            .map_err(|_| crate::coding::Error::UnexpectedEnd)?
+            .to_string();
+
+        Ok(SubscribeAnnouncesError {
+            track_namespace_prefix,
+            error_code,
+            reason_phrase,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let msg = SubscribeAnnouncesError {
+            track_namespace_prefix: vec!["a".to_string(), "b".to_string()],
+            error_code: VarInt(1),
+            reason_phrase: "err".to_string(),
+        };
+
+        let mut buf = bytes::BytesMut::new();
+        msg.encode(&mut buf);
+
+        let mut bytes = buf.freeze();
+        let decoded = SubscribeAnnouncesError::decode(&mut bytes).unwrap();
+
+        assert_eq!(decoded, msg);
     }
 }


### PR DESCRIPTION
## Summary
- implement the SubscribeAnnouncesError structure in Rust core
- add encode/decode and roundtrip test

## Testing
- `cargo test -p moqtail-core --lib -- tests --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_685789e790c4832992a91681cab92479