### PR TITLE
Implement Unsubscribe control message

### DIFF
--- a/packages/moqtail-core/src/message/unsubscribe.rs
+++ b/packages/moqtail-core/src/message/unsubscribe.rs
@@ -1,15 +1,40 @@
-use crate::coding::{Decode, Encode};
+use crate::coding::{Decode, Encode, VarInt};
+use bytes::{Buf, BufMut};
 
-pub struct Unsubscribe {}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Unsubscribe {
+    pub subscribe_id: VarInt,
+}
 
 impl Encode for Unsubscribe {
-    fn encode<B: bytes::BufMut>(&self, _buf: &mut B) {
-        todo!()
+    fn encode<B: BufMut>(&self, buf: &mut B) {
+        self.subscribe_id.encode(buf);
     }
 }
 
 impl<'a> Decode<'a> for Unsubscribe {
-    fn decode<B: bytes::Buf>(_buf: &mut B) -> Result<Self, crate::coding::Error> {
-        todo!()
+    fn decode<B: Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
+        let subscribe_id = VarInt::decode(buf)?;
+        Ok(Unsubscribe { subscribe_id })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let msg = Unsubscribe {
+            subscribe_id: VarInt(42),
+        };
+
+        let mut buf = bytes::BytesMut::new();
+        msg.encode(&mut buf);
+
+        let mut bytes = buf.freeze();
+        let decoded = Unsubscribe::decode(&mut bytes).unwrap();
+
+        assert_eq!(decoded, msg);
     }
 }


### PR DESCRIPTION
## Summary
- implement the UNSUBSCRIBE control message in `moqtail-core`
- add round‑trip test for `Unsubscribe`

## Testing
- `cargo test -p moqtail-core`

------
https://chatgpt.com/codex/tasks/task_e_68578c42ceb0832991362deec306363d