### PR TITLE
Handle binary track names

### DIFF
--- a/packages/moqtail-core/src/coding.rs
+++ b/packages/moqtail-core/src/coding.rs
@@ -9,6 +9,8 @@ pub enum Error {
     UnknownMessageType(VarInt),
     #[error("message length mismatch")]
     MessageLengthMismatch,
+    #[error("invalid track namespace length: {0}")]
+    InvalidTrackNamespaceLength(u64),
 }
 
 /// [Variable-Length Integer Encoding](https://datatracker.ietf.org/doc/html/rfc9000#name-variable-length-integer-enc)

--- a/packages/moqtail-core/src/message/announce.rs
+++ b/packages/moqtail-core/src/message/announce.rs
@@ -1,5 +1,5 @@
 use crate::coding::{Decode, Encode, VarInt};
-use crate::model::{Parameter, TrackNamespace};
+use crate::model::{decode_track_namespace, encode_track_namespace, Parameter, TrackNamespace};
 use bytes::{Buf, BufMut};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -10,11 +10,7 @@ pub struct Announce {
 
 impl Encode for Announce {
     fn encode<B: BufMut>(&self, buf: &mut B) {
-        VarInt(self.track_namespace.len() as u64).encode(buf);
-        for ns in &self.track_namespace {
-            VarInt(ns.as_bytes().len() as u64).encode(buf);
-            buf.put_slice(ns.as_bytes());
-        }
+        encode_track_namespace(&self.track_namespace, buf);
         VarInt(self.parameters.len() as u64).encode(buf);
         for p in &self.parameters {
             p.encode(buf);
@@ -24,19 +20,7 @@ impl Encode for Announce {
 
 impl<'a> Decode<'a> for Announce {
     fn decode<B: Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
-        let namespace_len = VarInt::decode(buf)?.into_inner() as usize;
-        let mut track_namespace = Vec::with_capacity(namespace_len);
-        for _ in 0..namespace_len {
-            let len = VarInt::decode(buf)?.into_inner() as usize;
-            if buf.remaining() < len {
-                return Err(crate::coding::Error::UnexpectedEnd);
-            }
-            let bytes = buf.copy_to_bytes(len);
-            let s = std::str::from_utf8(&bytes)
-                .map_err(|_| crate::coding::Error::UnexpectedEnd)?
-                .to_string();
-            track_namespace.push(s);
-        }
+        let track_namespace = decode_track_namespace(buf)?;
 
         let num_params = VarInt::decode(buf)?.into_inner() as usize;
         let mut parameters = Vec::with_capacity(num_params);
@@ -58,7 +42,7 @@ mod tests {
     #[test]
     fn encode_decode_roundtrip() {
         let msg = Announce {
-            track_namespace: vec!["ns1".to_string(), "ns2".to_string()],
+            track_namespace: vec![bytes::Bytes::from_static(b"ns1"), bytes::Bytes::from_static(b"ns2")],
             parameters: vec![Parameter::AuthorizationInfo("auth".into())],
         };
 

--- a/packages/moqtail-core/src/message/announce_cancel.rs
+++ b/packages/moqtail-core/src/message/announce_cancel.rs
@@ -1,5 +1,5 @@
 use crate::coding::{Decode, Encode, VarInt};
-use crate::model::TrackNamespace;
+use crate::model::{decode_track_namespace, encode_track_namespace, TrackNamespace};
 use bytes::{Buf, BufMut};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11,11 +11,7 @@ pub struct AnnounceCancel {
 
 impl Encode for AnnounceCancel {
     fn encode<B: BufMut>(&self, buf: &mut B) {
-        VarInt(self.track_namespace.len() as u64).encode(buf);
-        for ns in &self.track_namespace {
-            VarInt(ns.as_bytes().len() as u64).encode(buf);
-            buf.put_slice(ns.as_bytes());
-        }
+        encode_track_namespace(&self.track_namespace, buf);
         self.error_code.encode(buf);
         VarInt(self.reason_phrase.as_bytes().len() as u64).encode(buf);
         buf.put_slice(self.reason_phrase.as_bytes());
@@ -24,19 +20,7 @@ impl Encode for AnnounceCancel {
 
 impl<'a> Decode<'a> for AnnounceCancel {
     fn decode<B: Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
-        let namespace_len = VarInt::decode(buf)?.into_inner() as usize;
-        let mut track_namespace = Vec::with_capacity(namespace_len);
-        for _ in 0..namespace_len {
-            let len = VarInt::decode(buf)?.into_inner() as usize;
-            if buf.remaining() < len {
-                return Err(crate::coding::Error::UnexpectedEnd);
-            }
-            let bytes = buf.copy_to_bytes(len);
-            let ns = std::str::from_utf8(&bytes)
-                .map_err(|_| crate::coding::Error::UnexpectedEnd)?
-                .to_string();
-            track_namespace.push(ns);
-        }
+        let track_namespace = decode_track_namespace(buf)?;
 
         let error_code = VarInt::decode(buf)?;
 
@@ -64,7 +48,7 @@ mod tests {
     #[test]
     fn encode_decode_roundtrip() {
         let msg = AnnounceCancel {
-            track_namespace: vec!["ns1".to_string(), "ns2".to_string()],
+            track_namespace: vec![bytes::Bytes::from_static(b"ns1"), bytes::Bytes::from_static(b"ns2")],
             error_code: VarInt(1),
             reason_phrase: "cancel".to_string(),
         };

--- a/packages/moqtail-core/src/message/announce_error.rs
+++ b/packages/moqtail-core/src/message/announce_error.rs
@@ -1,5 +1,5 @@
 use crate::coding::{Decode, Encode, VarInt};
-use crate::model::TrackNamespace;
+use crate::model::{decode_track_namespace, encode_track_namespace, TrackNamespace};
 use bytes::{Buf, BufMut};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11,11 +11,7 @@ pub struct AnnounceError {
 
 impl Encode for AnnounceError {
     fn encode<B: bytes::BufMut>(&self, buf: &mut B) {
-        VarInt(self.track_namespace.len() as u64).encode(buf);
-        for ns in &self.track_namespace {
-            VarInt(ns.as_bytes().len() as u64).encode(buf);
-            buf.put_slice(ns.as_bytes());
-        }
+        encode_track_namespace(&self.track_namespace, buf);
         self.error_code.encode(buf);
         VarInt(self.reason_phrase.as_bytes().len() as u64).encode(buf);
         buf.put_slice(self.reason_phrase.as_bytes());
@@ -24,19 +20,7 @@ impl Encode for AnnounceError {
 
 impl<'a> Decode<'a> for AnnounceError {
     fn decode<B: Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
-        let namespace_len = VarInt::decode(buf)?.into_inner() as usize;
-        let mut track_namespace = Vec::with_capacity(namespace_len);
-        for _ in 0..namespace_len {
-            let len = VarInt::decode(buf)?.into_inner() as usize;
-            if buf.remaining() < len {
-                return Err(crate::coding::Error::UnexpectedEnd);
-            }
-            let bytes = buf.copy_to_bytes(len);
-            let s = std::str::from_utf8(&bytes)
-                .map_err(|_| crate::coding::Error::UnexpectedEnd)?
-                .to_string();
-            track_namespace.push(s);
-        }
+        let track_namespace = decode_track_namespace(buf)?;
 
         let error_code = VarInt::decode(buf)?;
 
@@ -64,7 +48,7 @@ mod tests {
     #[test]
     fn encode_decode_roundtrip() {
         let msg = AnnounceError {
-            track_namespace: vec!["ns1".to_string(), "ns2".to_string()],
+            track_namespace: vec![bytes::Bytes::from_static(b"ns1"), bytes::Bytes::from_static(b"ns2")],
             error_code: VarInt(1),
             reason_phrase: "err".to_string(),
         };

--- a/packages/moqtail-core/src/message/announce_ok.rs
+++ b/packages/moqtail-core/src/message/announce_ok.rs
@@ -1,5 +1,5 @@
 use crate::coding::{Decode, Encode, VarInt};
-use crate::model::TrackNamespace;
+use crate::model::{decode_track_namespace, encode_track_namespace, TrackNamespace};
 use bytes::{Buf, BufMut};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9,29 +9,13 @@ pub struct AnnounceOk {
 
 impl Encode for AnnounceOk {
     fn encode<B: BufMut>(&self, buf: &mut B) {
-        VarInt(self.track_namespace.len() as u64).encode(buf);
-        for ns in &self.track_namespace {
-            VarInt(ns.as_bytes().len() as u64).encode(buf);
-            buf.put_slice(ns.as_bytes());
-        }
+        encode_track_namespace(&self.track_namespace, buf);
     }
 }
 
 impl<'a> Decode<'a> for AnnounceOk {
     fn decode<B: Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
-        let namespace_len = VarInt::decode(buf)?.into_inner() as usize;
-        let mut track_namespace = Vec::with_capacity(namespace_len);
-        for _ in 0..namespace_len {
-            let len = VarInt::decode(buf)?.into_inner() as usize;
-            if buf.remaining() < len {
-                return Err(crate::coding::Error::UnexpectedEnd);
-            }
-            let bytes = buf.copy_to_bytes(len);
-            let s = std::str::from_utf8(&bytes)
-                .map_err(|_| crate::coding::Error::UnexpectedEnd)?
-                .to_string();
-            track_namespace.push(s);
-        }
+        let track_namespace = decode_track_namespace(buf)?;
 
         Ok(AnnounceOk { track_namespace })
     }
@@ -44,7 +28,7 @@ mod tests {
     #[test]
     fn encode_decode_roundtrip() {
         let msg = AnnounceOk {
-            track_namespace: vec!["live".to_string(), "video".to_string()],
+            track_namespace: vec![bytes::Bytes::from_static(b"live"), bytes::Bytes::from_static(b"video")],
         };
 
         let mut buf = bytes::BytesMut::new();

--- a/packages/moqtail-core/src/message/fetch.rs
+++ b/packages/moqtail-core/src/message/fetch.rs
@@ -1,5 +1,8 @@
 use crate::coding::{Decode, Encode, VarInt};
-use crate::model::{GroupOrder, Parameter, TrackName, TrackNamespace};
+use crate::model::{
+    decode_track_name, decode_track_namespace, encode_track_name, encode_track_namespace,
+    GroupOrder, Parameter, TrackName, TrackNamespace,
+};
 use bytes::{Buf, BufMut};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -50,18 +53,13 @@ impl Encode for Fetch {
         match self.fetch_type {
             FetchType::Standalone => {
                 if let Some(ns) = &self.track_namespace {
-                    VarInt(ns.len() as u64).encode(buf);
-                    for part in ns {
-                        VarInt(part.as_bytes().len() as u64).encode(buf);
-                        buf.put_slice(part.as_bytes());
-                    }
+                    encode_track_namespace(ns, buf);
                 } else {
                     VarInt(0).encode(buf);
                 }
 
                 if let Some(name) = &self.track_name {
-                    VarInt(name.as_bytes().len() as u64).encode(buf);
-                    buf.put_slice(name.as_bytes());
+                    encode_track_name(name, buf);
                 } else {
                     VarInt(0).encode(buf);
                 }
@@ -110,28 +108,9 @@ impl<'a> Decode<'a> for Fetch {
             preceding_group_offset,
         ) = match fetch_type {
             FetchType::Standalone => {
-                let ns_len = VarInt::decode(buf)?.into_inner() as usize;
-                let mut ns = Vec::with_capacity(ns_len);
-                for _ in 0..ns_len {
-                    let len = VarInt::decode(buf)?.into_inner() as usize;
-                    if buf.remaining() < len {
-                        return Err(crate::coding::Error::UnexpectedEnd);
-                    }
-                    let bytes = buf.copy_to_bytes(len);
-                    let s = std::str::from_utf8(&bytes)
-                        .map_err(|_| crate::coding::Error::UnexpectedEnd)?
-                        .to_string();
-                    ns.push(s);
-                }
+                let ns = decode_track_namespace(buf)?;
 
-                let name_len = VarInt::decode(buf)?.into_inner() as usize;
-                if buf.remaining() < name_len {
-                    return Err(crate::coding::Error::UnexpectedEnd);
-                }
-                let bytes = buf.copy_to_bytes(name_len);
-                let name = std::str::from_utf8(&bytes)
-                    .map_err(|_| crate::coding::Error::UnexpectedEnd)?
-                    .to_string();
+                let name = decode_track_name(buf)?;
 
                 let start_group = VarInt::decode(buf)?;
                 let start_object = VarInt::decode(buf)?;

--- a/packages/moqtail-core/src/message/subscribe.rs
+++ b/packages/moqtail-core/src/message/subscribe.rs
@@ -1,5 +1,8 @@
 use crate::coding::{Decode, Encode, VarInt};
-use crate::model::{GroupOrder, Parameter, SubscribeFilter, TrackAlias, TrackName, TrackNamespace};
+use crate::model::{
+    decode_track_name, decode_track_namespace, encode_track_name, encode_track_namespace,
+    GroupOrder, Parameter, SubscribeFilter, TrackAlias, TrackName, TrackNamespace,
+};
 use bytes::{Buf, BufMut};
 
 #[derive(Debug, Clone)]
@@ -21,13 +24,8 @@ impl Encode for Subscribe {
     fn encode<B: BufMut>(&self, buf: &mut B) {
         self.subscribe_id.encode(buf);
         self.track_alias.encode(buf);
-        VarInt(self.track_namespace.len() as u64).encode(buf);
-        for ns in &self.track_namespace {
-            VarInt(ns.as_bytes().len() as u64).encode(buf);
-            buf.put_slice(ns.as_bytes());
-        }
-        VarInt(self.track_name.as_bytes().len() as u64).encode(buf);
-        buf.put_slice(self.track_name.as_bytes());
+        encode_track_namespace(&self.track_namespace, buf);
+        encode_track_name(&self.track_name, buf);
         buf.put_u8(self.subscriber_priority);
         buf.put_u8(self.group_order.into());
         VarInt::from(self.filter_type).encode(buf);
@@ -62,28 +60,9 @@ impl<'a> Decode<'a> for Subscribe {
         let subscribe_id = VarInt::decode(buf)?;
         let track_alias = VarInt::decode(buf)?;
 
-        let namespace_len = VarInt::decode(buf)?.into_inner() as usize;
-        let mut track_namespace = Vec::with_capacity(namespace_len);
-        for _ in 0..namespace_len {
-            let len = VarInt::decode(buf)?.into_inner() as usize;
-            if buf.remaining() < len {
-                return Err(crate::coding::Error::UnexpectedEnd);
-            }
-            let bytes = buf.copy_to_bytes(len);
-            let s = std::str::from_utf8(&bytes)
-                .map_err(|_| crate::coding::Error::UnexpectedEnd)?
-                .to_string();
-            track_namespace.push(s);
-        }
+        let track_namespace = decode_track_namespace(buf)?;
 
-        let name_len = VarInt::decode(buf)?.into_inner() as usize;
-        if buf.remaining() < name_len {
-            return Err(crate::coding::Error::UnexpectedEnd);
-        }
-        let bytes = buf.copy_to_bytes(name_len);
-        let track_name = std::str::from_utf8(&bytes)
-            .map_err(|_| crate::coding::Error::UnexpectedEnd)?
-            .to_string();
+        let track_name = decode_track_name(buf)?;
 
         if !buf.has_remaining() {
             return Err(crate::coding::Error::UnexpectedEnd);

--- a/packages/moqtail-core/src/message/subscribe_announces.rs
+++ b/packages/moqtail-core/src/message/subscribe_announces.rs
@@ -1,5 +1,5 @@
 use crate::coding::{Decode, Encode, VarInt};
-use crate::model::{Parameter, TrackNamespace};
+use crate::model::{decode_track_namespace, encode_track_namespace, Parameter, TrackNamespace};
 use bytes::{Buf, BufMut};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -10,11 +10,7 @@ pub struct SubscribeAnnounces {
 
 impl Encode for SubscribeAnnounces {
     fn encode<B: BufMut>(&self, buf: &mut B) {
-        VarInt(self.track_namespace_prefix.len() as u64).encode(buf);
-        for ns in &self.track_namespace_prefix {
-            VarInt(ns.as_bytes().len() as u64).encode(buf);
-            buf.put_slice(ns.as_bytes());
-        }
+        encode_track_namespace(&self.track_namespace_prefix, buf);
         VarInt(self.parameters.len() as u64).encode(buf);
         for p in &self.parameters {
             p.encode(buf);
@@ -24,19 +20,7 @@ impl Encode for SubscribeAnnounces {
 
 impl<'a> Decode<'a> for SubscribeAnnounces {
     fn decode<B: Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
-        let len = VarInt::decode(buf)?.into_inner() as usize;
-        let mut track_namespace_prefix = Vec::with_capacity(len);
-        for _ in 0..len {
-            let l = VarInt::decode(buf)?.into_inner() as usize;
-            if buf.remaining() < l {
-                return Err(crate::coding::Error::UnexpectedEnd);
-            }
-            let bytes = buf.copy_to_bytes(l);
-            let ns = std::str::from_utf8(&bytes)
-                .map_err(|_| crate::coding::Error::UnexpectedEnd)?
-                .to_string();
-            track_namespace_prefix.push(ns);
-        }
+        let track_namespace_prefix = decode_track_namespace(buf)?;
 
         let num_params = VarInt::decode(buf)?.into_inner() as usize;
         let mut parameters = Vec::with_capacity(num_params);
@@ -58,7 +42,7 @@ mod tests {
     #[test]
     fn encode_decode_roundtrip() {
         let msg = SubscribeAnnounces {
-            track_namespace_prefix: vec!["ns1".to_string(), "ns2".to_string()],
+            track_namespace_prefix: vec![bytes::Bytes::from_static(b"ns1"), bytes::Bytes::from_static(b"ns2")],
             parameters: vec![Parameter::AuthorizationInfo("auth".into())],
         };
 

--- a/packages/moqtail-core/src/message/subscribe_announces_error.rs
+++ b/packages/moqtail-core/src/message/subscribe_announces_error.rs
@@ -1,5 +1,5 @@
 use crate::coding::{Decode, Encode, VarInt};
-use crate::model::TrackNamespace;
+use crate::model::{decode_track_namespace, encode_track_namespace, TrackNamespace};
 use bytes::{Buf, BufMut};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11,11 +11,7 @@ pub struct SubscribeAnnouncesError {
 
 impl Encode for SubscribeAnnouncesError {
     fn encode<B: bytes::BufMut>(&self, buf: &mut B) {
-        VarInt(self.track_namespace_prefix.len() as u64).encode(buf);
-        for ns in &self.track_namespace_prefix {
-            VarInt(ns.as_bytes().len() as u64).encode(buf);
-            buf.put_slice(ns.as_bytes());
-        }
+        encode_track_namespace(&self.track_namespace_prefix, buf);
         self.error_code.encode(buf);
         VarInt(self.reason_phrase.as_bytes().len() as u64).encode(buf);
         buf.put_slice(self.reason_phrase.as_bytes());
@@ -24,19 +20,7 @@ impl Encode for SubscribeAnnouncesError {
 
 impl<'a> Decode<'a> for SubscribeAnnouncesError {
     fn decode<B: bytes::Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
-        let namespace_len = VarInt::decode(buf)?.into_inner() as usize;
-        let mut track_namespace_prefix = Vec::with_capacity(namespace_len);
-        for _ in 0..namespace_len {
-            let len = VarInt::decode(buf)?.into_inner() as usize;
-            if buf.remaining() < len {
-                return Err(crate::coding::Error::UnexpectedEnd);
-            }
-            let bytes = buf.copy_to_bytes(len);
-            let s = std::str::from_utf8(&bytes)
-                .map_err(|_| crate::coding::Error::UnexpectedEnd)?
-                .to_string();
-            track_namespace_prefix.push(s);
-        }
+        let track_namespace_prefix = decode_track_namespace(buf)?;
 
         let error_code = VarInt::decode(buf)?;
 
@@ -64,7 +48,7 @@ mod tests {
     #[test]
     fn encode_decode_roundtrip() {
         let msg = SubscribeAnnouncesError {
-            track_namespace_prefix: vec!["a".to_string(), "b".to_string()],
+            track_namespace_prefix: vec![bytes::Bytes::from_static(b"a"), bytes::Bytes::from_static(b"b")],
             error_code: VarInt(1),
             reason_phrase: "err".to_string(),
         };

--- a/packages/moqtail-core/src/message/subscribe_announces_ok.rs
+++ b/packages/moqtail-core/src/message/subscribe_announces_ok.rs
@@ -1,5 +1,5 @@
 use crate::coding::{Decode, Encode, VarInt};
-use crate::model::TrackNamespace;
+use crate::model::{decode_track_namespace, encode_track_namespace, TrackNamespace};
 use bytes::{Buf, BufMut};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9,29 +9,13 @@ pub struct SubscribeAnnouncesOk {
 
 impl Encode for SubscribeAnnouncesOk {
     fn encode<B: bytes::BufMut>(&self, buf: &mut B) {
-        VarInt(self.track_namespace_prefix.len() as u64).encode(buf);
-        for ns in &self.track_namespace_prefix {
-            VarInt(ns.as_bytes().len() as u64).encode(buf);
-            buf.put_slice(ns.as_bytes());
-        }
+        encode_track_namespace(&self.track_namespace_prefix, buf);
     }
 }
 
 impl<'a> Decode<'a> for SubscribeAnnouncesOk {
     fn decode<B: bytes::Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
-        let namespace_len = VarInt::decode(buf)?.into_inner() as usize;
-        let mut track_namespace_prefix = Vec::with_capacity(namespace_len);
-        for _ in 0..namespace_len {
-            let len = VarInt::decode(buf)?.into_inner() as usize;
-            if buf.remaining() < len {
-                return Err(crate::coding::Error::UnexpectedEnd);
-            }
-            let bytes = buf.copy_to_bytes(len);
-            let s = std::str::from_utf8(&bytes)
-                .map_err(|_| crate::coding::Error::UnexpectedEnd)?
-                .to_string();
-            track_namespace_prefix.push(s);
-        }
+        let track_namespace_prefix = decode_track_namespace(buf)?;
 
         Ok(SubscribeAnnouncesOk {
             track_namespace_prefix,
@@ -46,7 +30,10 @@ mod tests {
     #[test]
     fn encode_decode_roundtrip() {
         let msg = SubscribeAnnouncesOk {
-            track_namespace_prefix: vec!["example".to_string(), "meeting=123".to_string()],
+            track_namespace_prefix: vec![
+                bytes::Bytes::from_static(b"example"),
+                bytes::Bytes::from_static(b"meeting=123"),
+            ],
         };
 
         let mut buf = bytes::BytesMut::new();

--- a/packages/moqtail-core/src/message/track_status.rs
+++ b/packages/moqtail-core/src/message/track_status.rs
@@ -1,5 +1,8 @@
 use crate::coding::{Decode, Encode, VarInt};
-use crate::model::{TrackName, TrackNamespace};
+use crate::model::{
+    decode_track_name, decode_track_namespace, encode_track_name, encode_track_namespace,
+    TrackName, TrackNamespace,
+};
 use bytes::{Buf, BufMut};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -13,13 +16,8 @@ pub struct TrackStatus {
 
 impl Encode for TrackStatus {
     fn encode<B: bytes::BufMut>(&self, buf: &mut B) {
-        VarInt(self.track_namespace.len() as u64).encode(buf);
-        for ns in &self.track_namespace {
-            VarInt(ns.as_bytes().len() as u64).encode(buf);
-            buf.put_slice(ns.as_bytes());
-        }
-        VarInt(self.track_name.as_bytes().len() as u64).encode(buf);
-        buf.put_slice(self.track_name.as_bytes());
+        encode_track_namespace(&self.track_namespace, buf);
+        encode_track_name(&self.track_name, buf);
         self.status_code.encode(buf);
         self.last_group_id.encode(buf);
         self.last_object_id.encode(buf);
@@ -28,28 +26,9 @@ impl Encode for TrackStatus {
 
 impl<'a> Decode<'a> for TrackStatus {
     fn decode<B: bytes::Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
-        let namespace_len = VarInt::decode(buf)?.into_inner() as usize;
-        let mut track_namespace = Vec::with_capacity(namespace_len);
-        for _ in 0..namespace_len {
-            let len = VarInt::decode(buf)?.into_inner() as usize;
-            if buf.remaining() < len {
-                return Err(crate::coding::Error::UnexpectedEnd);
-            }
-            let bytes = buf.copy_to_bytes(len);
-            let s = std::str::from_utf8(&bytes)
-                .map_err(|_| crate::coding::Error::UnexpectedEnd)?
-                .to_string();
-            track_namespace.push(s);
-        }
+        let track_namespace = decode_track_namespace(buf)?;
 
-        let name_len = VarInt::decode(buf)?.into_inner() as usize;
-        if buf.remaining() < name_len {
-            return Err(crate::coding::Error::UnexpectedEnd);
-        }
-        let bytes = buf.copy_to_bytes(name_len);
-        let track_name = std::str::from_utf8(&bytes)
-            .map_err(|_| crate::coding::Error::UnexpectedEnd)?
-            .to_string();
+        let track_name = decode_track_name(buf)?;
 
         let status_code = VarInt::decode(buf)?;
         let last_group_id = VarInt::decode(buf)?;
@@ -72,8 +51,8 @@ mod tests {
     #[test]
     fn encode_decode_roundtrip() {
         let msg = TrackStatus {
-            track_namespace: vec!["ns1".to_string(), "ns2".to_string()],
-            track_name: "track".to_string(),
+            track_namespace: vec![bytes::Bytes::from_static(b"ns1"), bytes::Bytes::from_static(b"ns2")],
+            track_name: bytes::Bytes::from_static(b"track"),
             status_code: VarInt(0),
             last_group_id: VarInt(1),
             last_object_id: VarInt(2),

--- a/packages/moqtail-core/src/message/track_status_request.rs
+++ b/packages/moqtail-core/src/message/track_status_request.rs
@@ -1,5 +1,8 @@
 use crate::coding::{Decode, Encode, VarInt};
-use crate::model::{TrackName, TrackNamespace};
+use crate::model::{
+    decode_track_name, decode_track_namespace, encode_track_name, encode_track_namespace,
+    TrackName, TrackNamespace,
+};
 use bytes::{Buf, BufMut};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -10,40 +13,16 @@ pub struct TrackStatusRequest {
 
 impl Encode for TrackStatusRequest {
     fn encode<B: BufMut>(&self, buf: &mut B) {
-        VarInt(self.track_namespace.len() as u64).encode(buf);
-        for ns in &self.track_namespace {
-            VarInt(ns.as_bytes().len() as u64).encode(buf);
-            buf.put_slice(ns.as_bytes());
-        }
-        VarInt(self.track_name.as_bytes().len() as u64).encode(buf);
-        buf.put_slice(self.track_name.as_bytes());
+        encode_track_namespace(&self.track_namespace, buf);
+        encode_track_name(&self.track_name, buf);
     }
 }
 
 impl<'a> Decode<'a> for TrackStatusRequest {
     fn decode<B: Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
-        let namespace_len = VarInt::decode(buf)?.into_inner() as usize;
-        let mut track_namespace = Vec::with_capacity(namespace_len);
-        for _ in 0..namespace_len {
-            let len = VarInt::decode(buf)?.into_inner() as usize;
-            if buf.remaining() < len {
-                return Err(crate::coding::Error::UnexpectedEnd);
-            }
-            let bytes = buf.copy_to_bytes(len);
-            let s = std::str::from_utf8(&bytes)
-                .map_err(|_| crate::coding::Error::UnexpectedEnd)?
-                .to_string();
-            track_namespace.push(s);
-        }
+        let track_namespace = decode_track_namespace(buf)?;
 
-        let name_len = VarInt::decode(buf)?.into_inner() as usize;
-        if buf.remaining() < name_len {
-            return Err(crate::coding::Error::UnexpectedEnd);
-        }
-        let bytes = buf.copy_to_bytes(name_len);
-        let track_name = std::str::from_utf8(&bytes)
-            .map_err(|_| crate::coding::Error::UnexpectedEnd)?
-            .to_string();
+        let track_name = decode_track_name(buf)?;
 
         Ok(TrackStatusRequest {
             track_namespace,
@@ -59,8 +38,8 @@ mod tests {
     #[test]
     fn encode_decode_roundtrip() {
         let msg = TrackStatusRequest {
-            track_namespace: vec!["ns1".to_string(), "ns2".to_string()],
-            track_name: "track".to_string(),
+            track_namespace: vec![bytes::Bytes::from_static(b"ns1"), bytes::Bytes::from_static(b"ns2")],
+            track_name: bytes::Bytes::from_static(b"track"),
         };
 
         let mut buf = bytes::BytesMut::new();

--- a/packages/moqtail-core/src/message/unannounce.rs
+++ b/packages/moqtail-core/src/message/unannounce.rs
@@ -1,5 +1,5 @@
 use crate::coding::{Decode, Encode, VarInt};
-use crate::model::TrackNamespace;
+use crate::model::{decode_track_namespace, encode_track_namespace, TrackNamespace};
 use bytes::{Buf, BufMut};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9,29 +9,13 @@ pub struct Unannounce {
 
 impl Encode for Unannounce {
     fn encode<B: bytes::BufMut>(&self, buf: &mut B) {
-        VarInt(self.track_namespace.len() as u64).encode(buf);
-        for ns in &self.track_namespace {
-            VarInt(ns.as_bytes().len() as u64).encode(buf);
-            buf.put_slice(ns.as_bytes());
-        }
+        encode_track_namespace(&self.track_namespace, buf);
     }
 }
 
 impl<'a> Decode<'a> for Unannounce {
     fn decode<B: bytes::Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
-        let len = VarInt::decode(buf)?.into_inner() as usize;
-        let mut track_namespace = Vec::with_capacity(len);
-        for _ in 0..len {
-            let l = VarInt::decode(buf)?.into_inner() as usize;
-            if buf.remaining() < l {
-                return Err(crate::coding::Error::UnexpectedEnd);
-            }
-            let bytes = buf.copy_to_bytes(l);
-            let s = std::str::from_utf8(&bytes)
-                .map_err(|_| crate::coding::Error::UnexpectedEnd)?
-                .to_string();
-            track_namespace.push(s);
-        }
+        let track_namespace = decode_track_namespace(buf)?;
 
         Ok(Unannounce { track_namespace })
     }
@@ -44,7 +28,7 @@ mod tests {
     #[test]
     fn encode_decode_roundtrip() {
         let msg = Unannounce {
-            track_namespace: vec!["ns1".to_string(), "ns2".to_string()],
+            track_namespace: vec![bytes::Bytes::from_static(b"ns1"), bytes::Bytes::from_static(b"ns2")],
         };
 
         let mut buf = bytes::BytesMut::new();

--- a/packages/moqtail-core/src/message/unsubscribe_announces.rs
+++ b/packages/moqtail-core/src/message/unsubscribe_announces.rs
@@ -1,5 +1,5 @@
 use crate::coding::{Decode, Encode, VarInt};
-use crate::model::TrackNamespace;
+use crate::model::{decode_track_namespace, encode_track_namespace, TrackNamespace};
 use bytes::{Buf, BufMut};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9,29 +9,13 @@ pub struct UnsubscribeAnnounces {
 
 impl Encode for UnsubscribeAnnounces {
     fn encode<B: bytes::BufMut>(&self, buf: &mut B) {
-        VarInt(self.track_namespace_prefix.len() as u64).encode(buf);
-        for ns in &self.track_namespace_prefix {
-            VarInt(ns.as_bytes().len() as u64).encode(buf);
-            buf.put_slice(ns.as_bytes());
-        }
+        encode_track_namespace(&self.track_namespace_prefix, buf);
     }
 }
 
 impl<'a> Decode<'a> for UnsubscribeAnnounces {
     fn decode<B: bytes::Buf>(buf: &mut B) -> Result<Self, crate::coding::Error> {
-        let len = VarInt::decode(buf)?.into_inner() as usize;
-        let mut track_namespace_prefix = Vec::with_capacity(len);
-        for _ in 0..len {
-            let l = VarInt::decode(buf)?.into_inner() as usize;
-            if buf.remaining() < l {
-                return Err(crate::coding::Error::UnexpectedEnd);
-            }
-            let bytes = buf.copy_to_bytes(l);
-            let s = std::str::from_utf8(&bytes)
-                .map_err(|_| crate::coding::Error::UnexpectedEnd)?
-                .to_string();
-            track_namespace_prefix.push(s);
-        }
+        let track_namespace_prefix = decode_track_namespace(buf)?;
 
         Ok(UnsubscribeAnnounces {
             track_namespace_prefix,
@@ -46,7 +30,7 @@ mod tests {
     #[test]
     fn encode_decode_roundtrip() {
         let msg = UnsubscribeAnnounces {
-            track_namespace_prefix: vec!["ns1".to_string(), "ns2".to_string()],
+            track_namespace_prefix: vec![bytes::Bytes::from_static(b"ns1"), bytes::Bytes::from_static(b"ns2")],
         };
 
         let mut buf = bytes::BytesMut::new();

--- a/packages/moqtail-core/src/model.rs
+++ b/packages/moqtail-core/src/model.rs
@@ -1,10 +1,51 @@
-use crate::coding::VarInt;
+use crate::coding::{Decode, Encode, Error, VarInt};
+use bytes::{Buf, BufMut};
 
-pub type TrackNamespace = Vec<String>;
+pub type TrackNamespace = Vec<bytes::Bytes>;
 
-pub type TrackName = String;
+pub type TrackName = bytes::Bytes;
 
 pub type TrackAlias = VarInt;
+
+pub fn encode_track_namespace<B: BufMut>(ns: &TrackNamespace, buf: &mut B) {
+    VarInt(ns.len() as u64).encode(buf);
+    for part in ns {
+        VarInt(part.len() as u64).encode(buf);
+        buf.put_slice(part);
+    }
+}
+
+pub fn decode_track_namespace<B: Buf>(
+    buf: &mut B,
+) -> Result<TrackNamespace, Error> {
+    let len = VarInt::decode(buf)?.into_inner() as usize;
+    if len == 0 || len > 32 {
+        return Err(Error::InvalidTrackNamespaceLength(len as u64));
+    }
+    let mut ns = Vec::with_capacity(len);
+    for _ in 0..len {
+        let l = VarInt::decode(buf)?.into_inner() as usize;
+        if buf.remaining() < l {
+            return Err(Error::UnexpectedEnd);
+        }
+        let bytes = buf.copy_to_bytes(l);
+        ns.push(bytes);
+    }
+    Ok(ns)
+}
+
+pub fn encode_track_name<B: BufMut>(name: &TrackName, buf: &mut B) {
+    VarInt(name.len() as u64).encode(buf);
+    buf.put_slice(name);
+}
+
+pub fn decode_track_name<B: Buf>(buf: &mut B) -> Result<TrackName, Error> {
+    let len = VarInt::decode(buf)?.into_inner() as usize;
+    if buf.remaining() < len {
+        return Err(Error::UnexpectedEnd);
+    }
+    Ok(buf.copy_to_bytes(len))
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FullTrackName {


### PR DESCRIPTION
## Summary
- support binary track identifiers in `model`
- update message codecs to use helper functions
- adjust tests for new binary formats

## Testing
- `cargo test -p moqtail-core -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68578fa91e44832996d80b2ad2987ed1