### PR TITLE
Fix VarInt parsing and add model tests

### DIFF
--- a/packages/moqtail-core/src/coding.rs
+++ b/packages/moqtail-core/src/coding.rs
@@ -76,10 +76,66 @@ impl<'a> Decode<'a> for VarInt {
 
         Ok(Self(match tag {
             0b00 => val,
-            0b01 => (val << 8 | buf.get_u8() as u64),
-            0b10 => (val << 24 | buf.get_u32() as u64) >> 8,
-            0b11 => (val << 56 | buf.get_u64() as u64) >> 8,
+            0b01 => {
+                if buf.remaining() < 1 {
+                    return Err(Error::UnexpectedEnd);
+                }
+                (val << 8) | buf.get_u8() as u64
+            }
+            0b10 => {
+                if buf.remaining() < 3 {
+                    return Err(Error::UnexpectedEnd);
+                }
+                (val << 24) | buf.get_uint(3)
+            }
+            0b11 => {
+                if buf.remaining() < 7 {
+                    return Err(Error::UnexpectedEnd);
+                }
+                (val << 56) | buf.get_uint(7)
+            }
             _ => unreachable!(),
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::{Buf, BufMut};
+
+    fn roundtrip(v: u64) {
+        let vi = VarInt(v);
+        let mut buf = bytes::BytesMut::new();
+        vi.encode(&mut buf);
+        let mut bytes = buf.freeze();
+        let decoded = VarInt::decode(&mut bytes).unwrap();
+        assert_eq!(decoded, vi);
+        assert!(!bytes.has_remaining());
+    }
+
+    #[test]
+    fn varint_encode_decode_roundtrip() {
+        let values = [
+            0,
+            63,
+            64,
+            16383,
+            16384,
+            1_000_000,
+            (1 << 30) - 1,
+            1 << 30,
+            (1 << 62) - 1,
+        ];
+        for &v in &values {
+            roundtrip(v);
+        }
+    }
+
+    #[test]
+    fn decode_unexpected_end() {
+        let mut buf = bytes::Bytes::from_static(&[0b01 << 6 | 0x3f]);
+        let res = VarInt::decode(&mut buf);
+        assert!(matches!(res, Err(Error::UnexpectedEnd)));
     }
 }

--- a/packages/moqtail-core/src/model.rs
+++ b/packages/moqtail-core/src/model.rs
@@ -251,3 +251,44 @@ impl From<SubscribeFilter> for VarInt {
         VarInt(f as u64)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::{Buf, BufMut};
+
+    #[test]
+    fn track_namespace_roundtrip() {
+        let ns = vec![bytes::Bytes::from_static(b"foo"), bytes::Bytes::from_static(b"bar")];
+        let mut buf = bytes::BytesMut::new();
+        encode_track_namespace(&ns, &mut buf);
+        let mut bytes = buf.freeze();
+        let decoded = decode_track_namespace(&mut bytes).unwrap();
+        assert_eq!(decoded, ns);
+        assert!(!bytes.has_remaining());
+    }
+
+    #[test]
+    fn track_namespace_invalid_length() {
+        let mut buf = bytes::Bytes::from_static(&[0]);
+        let res = decode_track_namespace(&mut buf);
+        assert!(matches!(res, Err(Error::InvalidTrackNamespaceLength(0))));
+
+        let mut buf = bytes::BytesMut::new();
+        VarInt(33).encode(&mut buf);
+        let mut bytes = buf.freeze();
+        let res = decode_track_namespace(&mut bytes);
+        assert!(matches!(res, Err(Error::InvalidTrackNamespaceLength(33))));
+    }
+
+    #[test]
+    fn track_name_roundtrip() {
+        let name = bytes::Bytes::from_static(b"video");
+        let mut buf = bytes::BytesMut::new();
+        encode_track_name(&name, &mut buf);
+        let mut bytes = buf.freeze();
+        let decoded = decode_track_name(&mut bytes).unwrap();
+        assert_eq!(decoded, name);
+        assert!(!bytes.has_remaining());
+    }
+}


### PR DESCRIPTION
## Summary
- fix `VarInt` decoding to read the correct number of bytes
- add unit tests for `VarInt`
- add encode/decode tests for track namespace and name

## Testing
- `cargo test -p moqtail-core -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68579243ec288329a4e7fe6db31d2df3