### PR TITLE
Fix parameter length handling in control messages

### DIFF
--- a/packages/moqtail-core/src/coding.rs
+++ b/packages/moqtail-core/src/coding.rs
@@ -11,6 +11,8 @@ pub enum Error {
     MessageLengthMismatch,
     #[error("invalid track namespace length: {0}")]
     InvalidTrackNamespaceLength(u64),
+    #[error("parameter length mismatch")]
+    ParameterLengthMismatch,
 }
 
 /// [Variable-Length Integer Encoding](https://datatracker.ietf.org/doc/html/rfc9000#name-variable-length-integer-enc)

--- a/packages/moqtail-core/src/model.rs
+++ b/packages/moqtail-core/src/model.rs
@@ -114,8 +114,15 @@ impl<'a> crate::coding::Decode<'a> for SetupParameter {
                 Ok(SetupParameter::Path(path))
             }
             0x02 => {
-                let _len = VarInt::decode(buf)?;
-                let val = VarInt::decode(buf)?;
+                let len = VarInt::decode(buf)?.into_inner() as usize;
+                if buf.remaining() < len {
+                    return Err(crate::coding::Error::UnexpectedEnd);
+                }
+                let mut bytes = buf.copy_to_bytes(len);
+                let val = VarInt::decode(&mut bytes)?;
+                if bytes.has_remaining() {
+                    return Err(crate::coding::Error::ParameterLengthMismatch);
+                }
                 Ok(SetupParameter::MaxSubscribeId(val))
             }
             _ => {
@@ -185,13 +192,27 @@ impl<'a> crate::coding::Decode<'a> for Parameter {
                 Ok(Parameter::AuthorizationInfo(info))
             }
             0x03 => {
-                let _len = VarInt::decode(buf)?;
-                let v = VarInt::decode(buf)?;
+                let len = VarInt::decode(buf)?.into_inner() as usize;
+                if buf.remaining() < len {
+                    return Err(crate::coding::Error::UnexpectedEnd);
+                }
+                let mut bytes = buf.copy_to_bytes(len);
+                let v = VarInt::decode(&mut bytes)?;
+                if bytes.has_remaining() {
+                    return Err(crate::coding::Error::ParameterLengthMismatch);
+                }
                 Ok(Parameter::DeliveryTimeout(v))
             }
             0x04 => {
-                let _len = VarInt::decode(buf)?;
-                let v = VarInt::decode(buf)?;
+                let len = VarInt::decode(buf)?.into_inner() as usize;
+                if buf.remaining() < len {
+                    return Err(crate::coding::Error::UnexpectedEnd);
+                }
+                let mut bytes = buf.copy_to_bytes(len);
+                let v = VarInt::decode(&mut bytes)?;
+                if bytes.has_remaining() {
+                    return Err(crate::coding::Error::ParameterLengthMismatch);
+                }
                 Ok(Parameter::MaxCacheDuration(v))
             }
             _ => {
@@ -249,5 +270,43 @@ impl From<VarInt> for SubscribeFilter {
 impl From<SubscribeFilter> for VarInt {
     fn from(f: SubscribeFilter) -> Self {
         VarInt(f as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::BufMut;
+
+    #[test]
+    fn setup_parameter_length_mismatch() {
+        // encode MaxSubscribeId with length larger than actual
+        let mut buf = bytes::BytesMut::new();
+        VarInt(0x02).encode(&mut buf); // type
+        let mut tmp = bytes::BytesMut::new();
+        VarInt(300).encode(&mut tmp); // encoded varint uses 2 bytes
+        VarInt(tmp.len() as u64 + 1).encode(&mut buf); // declare length 3
+        buf.extend_from_slice(&tmp);
+        buf.put_u8(0); // extra padding
+
+        let mut bytes = buf.freeze();
+        let res = SetupParameter::decode(&mut bytes);
+        assert!(matches!(res, Err(crate::coding::Error::ParameterLengthMismatch)));
+    }
+
+    #[test]
+    fn parameter_length_mismatch() {
+        // encode DeliveryTimeout with length larger than actual
+        let mut buf = bytes::BytesMut::new();
+        VarInt(0x03).encode(&mut buf); // type
+        let mut tmp = bytes::BytesMut::new();
+        VarInt(150).encode(&mut tmp); // encoded varint uses 2 bytes
+        VarInt(tmp.len() as u64 + 1).encode(&mut buf); // declare length 3
+        buf.extend_from_slice(&tmp);
+        buf.put_u8(0);
+
+        let mut bytes = buf.freeze();
+        let res = Parameter::decode(&mut bytes);
+        assert!(matches!(res, Err(crate::coding::Error::ParameterLengthMismatch)));
     }
 }


### PR DESCRIPTION
## Summary
- enforce Parameter Length checks when decoding Setup and regular Parameters
- introduce `ParameterLengthMismatch` error type
- add unit tests for length mismatch cases

## Testing
- `cargo test -p moqtail-core -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68579281c5ac832991ba12f61a663fad