### PR TITLE
Add fetch stream and datagram decoding support

### DIFF
--- a/packages/moqtail-core/src/datastream.rs
+++ b/packages/moqtail-core/src/datastream.rs
@@ -1,7 +1,7 @@
 // Data stream types and serialization utilities for MOQT
 
 use crate::coding::{Decode, Encode, Error, VarInt};
-use crate::model::{TrackAlias};
+use crate::model::TrackAlias;
 use bytes::{Buf, BufMut};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -147,7 +147,12 @@ pub fn decode_subgroup_header<B: Buf>(buf: &mut B) -> Result<SubgroupHeader, Err
         return Err(Error::UnexpectedEnd);
     }
     let publisher_priority = buf.get_u8();
-    Ok(SubgroupHeader { track_alias, group_id, subgroup_id, publisher_priority })
+    Ok(SubgroupHeader {
+        track_alias,
+        group_id,
+        subgroup_id,
+        publisher_priority,
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -188,7 +193,89 @@ pub fn decode_subgroup_object_header<B: Buf>(buf: &mut B) -> Result<SubgroupObje
     } else {
         None
     };
-    Ok(SubgroupObjectHeader { object_id, extension_headers, object_status })
+    Ok(SubgroupObjectHeader {
+        object_id,
+        extension_headers,
+        object_status,
+    })
+}
+
+#[derive(Debug, Clone)]
+pub struct FetchHeader {
+    pub subscribe_id: VarInt,
+}
+
+pub fn encode_fetch_header<B: BufMut>(header: &FetchHeader, buf: &mut B) {
+    VarInt(StreamType::FetchHeader as u64).encode(buf);
+    header.subscribe_id.encode(buf);
+}
+
+pub fn decode_fetch_header<B: Buf>(buf: &mut B) -> Result<FetchHeader, Error> {
+    let subscribe_id = VarInt::decode(buf)?;
+    Ok(FetchHeader { subscribe_id })
+}
+
+#[derive(Debug, Clone)]
+pub struct FetchObject {
+    pub group_id: VarInt,
+    pub subgroup_id: VarInt,
+    pub object_id: VarInt,
+    pub publisher_priority: u8,
+    pub extension_headers: Vec<ExtensionHeader>,
+    pub object_status: Option<ObjectStatus>,
+    pub payload: bytes::Bytes,
+}
+
+impl Encode for FetchObject {
+    fn encode<B: BufMut>(&self, buf: &mut B) {
+        self.group_id.encode(buf);
+        self.subgroup_id.encode(buf);
+        self.object_id.encode(buf);
+        buf.put_u8(self.publisher_priority);
+        encode_extension_headers(&self.extension_headers, buf);
+        VarInt(self.payload.len() as u64).encode(buf);
+        if self.payload.is_empty() {
+            if let Some(status) = self.object_status {
+                VarInt::from(status).encode(buf);
+            }
+        }
+        buf.put_slice(&self.payload);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FetchObjectHeader {
+    pub group_id: VarInt,
+    pub subgroup_id: VarInt,
+    pub object_id: VarInt,
+    pub publisher_priority: u8,
+    pub extension_headers: Vec<ExtensionHeader>,
+    pub object_status: Option<ObjectStatus>,
+}
+
+pub fn decode_fetch_object_header<B: Buf>(buf: &mut B) -> Result<FetchObjectHeader, Error> {
+    let group_id = VarInt::decode(buf)?;
+    let subgroup_id = VarInt::decode(buf)?;
+    let object_id = VarInt::decode(buf)?;
+    if !buf.has_remaining() {
+        return Err(Error::UnexpectedEnd);
+    }
+    let publisher_priority = buf.get_u8();
+    let extension_headers = decode_extension_headers(buf)?;
+    let payload_len = VarInt::decode(buf)?.into_inner() as usize;
+    let object_status = if payload_len == 0 {
+        Some(ObjectStatus::from(VarInt::decode(buf)?))
+    } else {
+        None
+    };
+    Ok(FetchObjectHeader {
+        group_id,
+        subgroup_id,
+        object_id,
+        publisher_priority,
+        extension_headers,
+        object_status,
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -236,7 +323,22 @@ pub fn decode_datagram_header<B: Buf>(buf: &mut B) -> Result<DatagramHeader, Err
     }
     let publisher_priority = buf.get_u8();
     let extension_headers = decode_extension_headers(buf)?;
-    Ok(DatagramHeader { track_alias, group_id, object_id, publisher_priority, extension_headers })
+    Ok(DatagramHeader {
+        track_alias,
+        group_id,
+        object_id,
+        publisher_priority,
+        extension_headers,
+    })
+}
+
+pub fn decode_datagram<B: Buf>(
+    buf: &mut B,
+) -> Result<(DatagramType, DatagramHeader, bytes::Bytes), Error> {
+    let dgram_type = DatagramType::from(VarInt::decode(buf)?);
+    let header = decode_datagram_header(buf)?;
+    let payload = buf.copy_to_bytes(buf.remaining());
+    Ok((dgram_type, header, payload))
 }
 
 #[cfg(test)]
@@ -246,12 +348,19 @@ mod tests {
 
     #[test]
     fn extension_header_roundtrip() {
-        let header = ExtensionHeader { id: VarInt(2), value: ExtensionHeaderValue::VarInt(VarInt(5)) };
+        let header = ExtensionHeader {
+            id: VarInt(2),
+            value: ExtensionHeaderValue::VarInt(VarInt(5)),
+        };
         let mut buf = BytesMut::new();
         header.encode(&mut buf);
         let mut bytes = buf.freeze();
         let decoded = ExtensionHeader::decode(&mut bytes).unwrap();
-        if let ExtensionHeaderValue::VarInt(v) = decoded.value { assert_eq!(v, VarInt(5)); } else { panic!("wrong variant"); }
+        if let ExtensionHeaderValue::VarInt(v) = decoded.value {
+            assert_eq!(v, VarInt(5));
+        } else {
+            panic!("wrong variant");
+        }
         let mut multi = BytesMut::new();
         encode_extension_headers(&[header.clone()], &mut multi);
         assert!(multi.len() > 0);
@@ -259,7 +368,14 @@ mod tests {
 
     #[test]
     fn datagram_header_roundtrip() {
-        let dg = Datagram { track_alias: VarInt(1), group_id: VarInt(2), object_id: VarInt(3), publisher_priority: 4, extension_headers: Vec::new(), payload: BytesMut::from(&[5u8][..]).freeze() };
+        let dg = Datagram {
+            track_alias: VarInt(1),
+            group_id: VarInt(2),
+            object_id: VarInt(3),
+            publisher_priority: 4,
+            extension_headers: Vec::new(),
+            payload: BytesMut::from(&[5u8][..]).freeze(),
+        };
         let mut buf = BytesMut::new();
         dg.encode(&mut buf);
         let encoded = buf.freeze();
@@ -273,7 +389,12 @@ mod tests {
 
     #[test]
     fn subgroup_header_roundtrip() {
-        let sg = SubgroupHeader { track_alias: VarInt(1), group_id: VarInt(2), subgroup_id: VarInt(3), publisher_priority: 4 };
+        let sg = SubgroupHeader {
+            track_alias: VarInt(1),
+            group_id: VarInt(2),
+            subgroup_id: VarInt(3),
+            publisher_priority: 4,
+        };
         let mut buf = BytesMut::new();
         encode_subgroup_header(&sg, &mut buf);
         let encoded = buf.freeze();
@@ -287,7 +408,12 @@ mod tests {
 
     #[test]
     fn subgroup_object_roundtrip() {
-        let obj = SubgroupObject { object_id: VarInt(1), extension_headers: Vec::new(), object_status: None, payload: BytesMut::from(&[1u8][..]).freeze() };
+        let obj = SubgroupObject {
+            object_id: VarInt(1),
+            extension_headers: Vec::new(),
+            object_status: None,
+            payload: BytesMut::from(&[1u8][..]).freeze(),
+        };
         let mut buf = BytesMut::new();
         obj.encode(&mut buf);
         let encoded = buf.freeze();
@@ -296,5 +422,59 @@ mod tests {
         let header = decode_subgroup_object_header(&mut header_bytes).unwrap();
         assert_eq!(header.object_id, obj.object_id);
     }
-}
 
+    #[test]
+    fn fetch_header_roundtrip() {
+        let fh = FetchHeader {
+            subscribe_id: VarInt(42),
+        };
+        let mut buf = BytesMut::new();
+        encode_fetch_header(&fh, &mut buf);
+        let encoded = buf.freeze();
+        let mut header_bytes = encoded.slice(1..); // skip stream type
+        let decoded = decode_fetch_header(&mut header_bytes).unwrap();
+        assert_eq!(decoded.subscribe_id, fh.subscribe_id);
+    }
+
+    #[test]
+    fn fetch_object_roundtrip() {
+        let obj = FetchObject {
+            group_id: VarInt(1),
+            subgroup_id: VarInt(2),
+            object_id: VarInt(3),
+            publisher_priority: 4,
+            extension_headers: Vec::new(),
+            object_status: None,
+            payload: BytesMut::from(&[1u8, 2u8][..]).freeze(),
+        };
+        let mut buf = BytesMut::new();
+        obj.encode(&mut buf);
+        let encoded = buf.freeze();
+        let header_len = encoded.len() - obj.payload.len();
+        let mut header_bytes = encoded.slice(..header_len);
+        let header = decode_fetch_object_header(&mut header_bytes).unwrap();
+        assert_eq!(header.group_id, obj.group_id);
+        assert_eq!(header.subgroup_id, obj.subgroup_id);
+        assert_eq!(header.object_id, obj.object_id);
+        assert_eq!(header.publisher_priority, obj.publisher_priority);
+    }
+
+    #[test]
+    fn datagram_roundtrip() {
+        let dg = Datagram {
+            track_alias: VarInt(1),
+            group_id: VarInt(2),
+            object_id: VarInt(3),
+            publisher_priority: 4,
+            extension_headers: Vec::new(),
+            payload: BytesMut::from(&[9u8][..]).freeze(),
+        };
+        let mut buf = BytesMut::new();
+        dg.encode(&mut buf);
+        let mut bytes = buf.freeze();
+        let (dgram_type, header, payload) = decode_datagram(&mut bytes).unwrap();
+        assert_eq!(dgram_type, DatagramType::Object);
+        assert_eq!(header.object_id, dg.object_id);
+        assert_eq!(payload, dg.payload);
+    }
+}


### PR DESCRIPTION
## Summary
- add fetch header/objects to datastream implementation
- implement datagram decoder
- test new datastream pieces

## Testing
- `cargo test -p moqtail-core`
- `cargo check -p moqtail-wasm`

------
https://chatgpt.com/codex/tasks/task_e_6857a2c4f8dc83299f725db9353e0b77