### PR TITLE
Implement subscribe/fetch state management

### DIFF
--- a/packages/moqtail-core/src/session.rs
+++ b/packages/moqtail-core/src/session.rs
@@ -1,10 +1,14 @@
 use crate::coding::{Decode, Encode, VarInt};
 use crate::message::{
-    ClientSetup, ControlMessage, ServerSetup, Subscribe, SubscribeError, SubscribeOk,
+    ClientSetup, ControlMessage, Fetch, FetchCancel, FetchError, FetchOk, FetchType,
+    ServerSetup,
+    Subscribe, SubscribeAnnounces, SubscribeAnnouncesError, SubscribeAnnouncesOk,
+    SubscribeError, SubscribeOk, Unsubscribe,
 };
 use crate::model::*;
 use async_trait::async_trait;
 use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use std::collections::HashMap;
 
 /// Error codes used when closing a session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27,11 +31,28 @@ impl From<SessionCloseCode> for VarInt {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubscribeState {
+    Pending,
+    Active,
+    Done,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FetchState {
+    Pending,
+    Active,
+    Error,
+}
+
 pub struct Session<T: MoqConnection> {
     conn: T,
     control_stream: T::BiStream,
     version: VarInt,
     next_subscribe_id: u64,
+    subscribes: HashMap<u64, SubscribeState>,
+    fetches: HashMap<u64, FetchState>,
 }
 
 impl<T: MoqConnection> Session<T> {
@@ -88,6 +109,8 @@ impl<T: MoqConnection> Session<T> {
             control_stream,
             version,
             next_subscribe_id: 0,
+            subscribes: HashMap::new(),
+            fetches: HashMap::new(),
         })
     }
 
@@ -98,6 +121,10 @@ impl<T: MoqConnection> Session<T> {
     ) -> Result<(), T::Error> {
         let sub_id = self.next_subscribe_id;
         self.next_subscribe_id += 1;
+
+        if self.subscribes.contains_key(&sub_id) {
+            return Err(std::io::Error::new(std::io::ErrorKind::Other, "duplicate subscribe id").into());
+        }
 
         let msg = Subscribe {
             subscribe_id: VarInt(sub_id),
@@ -117,6 +144,8 @@ impl<T: MoqConnection> Session<T> {
         ControlMessage::Subscribe(msg).encode(&mut buf);
         self.control_stream.write_all(&buf).await?;
 
+        self.subscribes.insert(sub_id, SubscribeState::Pending);
+
         // Wait for a response on the control stream. In a fully fledged
         // implementation we would handle interleaved messages, but for now we
         // simply expect the next message to correspond to this subscribe.
@@ -128,10 +157,12 @@ impl<T: MoqConnection> Session<T> {
             Ok(ControlMessage::SubscribeOk(SubscribeOk { subscribe_id, .. }))
                 if subscribe_id.0 == sub_id =>
             {
+                self.subscribes.insert(sub_id, SubscribeState::Active);
                 Ok(())
             }
             Ok(ControlMessage::SubscribeError(SubscribeError { reason_phrase, .. })) => {
                 log::error!("subscribe failed: {}", reason_phrase);
+                self.subscribes.insert(sub_id, SubscribeState::Error);
                 Err(std::io::Error::new(std::io::ErrorKind::Other, reason_phrase).into())
             }
             Ok(_other) => {
@@ -140,6 +171,106 @@ impl<T: MoqConnection> Session<T> {
             }
             Err(_) => Err(std::io::Error::new(std::io::ErrorKind::Other, "decode error").into()),
         }
+    }
+
+    pub async fn unsubscribe(&mut self, subscribe_id: u64) -> Result<(), T::Error> {
+        let msg = Unsubscribe {
+            subscribe_id: VarInt(subscribe_id as u64),
+        };
+        let mut buf = bytes::BytesMut::new();
+        ControlMessage::Unsubscribe(msg).encode(&mut buf);
+        self.control_stream.write_all(&buf).await?;
+        self.subscribes.remove(&subscribe_id);
+        Ok(())
+    }
+
+    pub async fn subscribe_announces(
+        &mut self,
+        namespace: TrackNamespace,
+    ) -> Result<(), T::Error> {
+        let msg = SubscribeAnnounces {
+            track_namespace_prefix: namespace,
+            parameters: Vec::new(),
+        };
+        let mut buf = bytes::BytesMut::new();
+        ControlMessage::SubscribeAnnounces(msg).encode(&mut buf);
+        self.control_stream.write_all(&buf).await?;
+
+        let mut read_buf = [0u8; 1024];
+        let n = self.control_stream.read(&mut read_buf).await?;
+        let mut bytes = bytes::Bytes::copy_from_slice(&read_buf[..n]);
+
+        match ControlMessage::decode(&mut bytes) {
+            Ok(ControlMessage::SubscribeAnnouncesOk(_)) => Ok(()),
+            Ok(ControlMessage::SubscribeAnnouncesError(e)) => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                e.reason_phrase,
+            )
+            .into()),
+            _ => Err(std::io::Error::new(std::io::ErrorKind::Other, "protocol error").into()),
+        }
+    }
+
+    pub async fn fetch(
+        &mut self,
+        namespace: TrackNamespace,
+        name: TrackName,
+    ) -> Result<u64, T::Error> {
+        let id = self.next_subscribe_id;
+        self.next_subscribe_id += 1;
+
+        if self.fetches.contains_key(&id) {
+            return Err(std::io::Error::new(std::io::ErrorKind::Other, "duplicate fetch id").into());
+        }
+
+        let msg = Fetch {
+            subscribe_id: VarInt(id),
+            subscriber_priority: 0,
+            group_order: GroupOrder::Publisher,
+            fetch_type: FetchType::Standalone,
+            track_namespace: Some(namespace),
+            track_name: Some(name),
+            start_group: Some(VarInt(0)),
+            start_object: Some(VarInt(0)),
+            end_group: Some(VarInt(0)),
+            end_object: Some(VarInt(0)),
+            joining_subscribe_id: None,
+            preceding_group_offset: None,
+            parameters: Vec::new(),
+        };
+
+        let mut buf = bytes::BytesMut::new();
+        ControlMessage::Fetch(msg).encode(&mut buf);
+        self.control_stream.write_all(&buf).await?;
+
+        self.fetches.insert(id, FetchState::Pending);
+
+        let mut read_buf = [0u8; 1024];
+        let n = self.control_stream.read(&mut read_buf).await?;
+        let mut bytes = bytes::Bytes::copy_from_slice(&read_buf[..n]);
+
+        match ControlMessage::decode(&mut bytes) {
+            Ok(ControlMessage::FetchOk(FetchOk { subscribe_id, .. })) if subscribe_id.0 == id => {
+                self.fetches.insert(id, FetchState::Active);
+                Ok(id)
+            }
+            Ok(ControlMessage::FetchError(FetchError { reason_phrase, .. })) => {
+                self.fetches.insert(id, FetchState::Error);
+                Err(std::io::Error::new(std::io::ErrorKind::Other, reason_phrase).into())
+            }
+            _ => Err(std::io::Error::new(std::io::ErrorKind::Other, "protocol error").into()),
+        }
+    }
+
+    pub async fn fetch_cancel(&mut self, id: u64) -> Result<(), T::Error> {
+        let msg = FetchCancel {
+            subscribe_id: VarInt(id),
+        };
+        let mut buf = bytes::BytesMut::new();
+        ControlMessage::FetchCancel(msg).encode(&mut buf);
+        self.control_stream.write_all(&buf).await?;
+        self.fetches.remove(&id);
+        Ok(())
     }
 
     /// Simple event loop that polls the underlying transport for new events.
@@ -204,8 +335,10 @@ mod tests {
     use std::io;
     use std::sync::{Arc, Mutex};
 
+    use std::collections::VecDeque;
+
     struct DummyBiStream {
-        read: Cursor<Vec<u8>>,
+        reads: VecDeque<Cursor<Vec<u8>>>,
         written: Arc<Mutex<Vec<u8>>>,
     }
 
@@ -215,7 +348,20 @@ mod tests {
             cx: &mut std::task::Context<'_>,
             buf: &mut [u8],
         ) -> std::task::Poll<Result<usize, io::Error>> {
-            std::pin::Pin::new(&mut self.read).poll_read(cx, buf)
+            loop {
+                if let Some(front) = self.reads.front_mut() {
+                    match std::pin::Pin::new(front).poll_read(cx, buf)? {
+                        std::task::Poll::Ready(0) => {
+                            self.reads.pop_front();
+                            continue;
+                        }
+                        std::task::Poll::Ready(n) => return std::task::Poll::Ready(Ok(n)),
+                        std::task::Poll::Pending => return std::task::Poll::Pending,
+                    }
+                } else {
+                    return std::task::Poll::Ready(Ok(0));
+                }
+            }
         }
     }
 
@@ -276,7 +422,7 @@ mod tests {
     impl Unpin for DummyUniStream {}
 
     struct MockConnection {
-        read: Vec<u8>,
+        read: VecDeque<Vec<u8>>,
         written: Arc<Mutex<Vec<u8>>>,
     }
 
@@ -288,8 +434,13 @@ mod tests {
         type Error = io::Error;
 
         async fn open_bi(&mut self) -> Result<Self::BiStream, Self::Error> {
+            let reads = self
+                .read
+                .drain(..)
+                .map(|v| Cursor::new(v))
+                .collect::<VecDeque<_>>();
             Ok(DummyBiStream {
-                read: Cursor::new(std::mem::take(&mut self.read)),
+                reads,
                 written: self.written.clone(),
             })
         }
@@ -322,7 +473,7 @@ mod tests {
 
             let written = Arc::new(Mutex::new(Vec::new()));
             let conn = MockConnection {
-                read: resp.to_vec(),
+                read: VecDeque::from(vec![resp.to_vec()]),
                 written: written.clone(),
             };
 
@@ -341,6 +492,79 @@ mod tests {
                 }
                 _ => panic!("unexpected message"),
             }
+        });
+    }
+
+    #[test]
+    fn subscribe_ok_updates_state() {
+        block_on(async {
+            let server_setup = ServerSetup {
+                selected_version: VarInt(1),
+                parameters: Vec::new(),
+            };
+            let sub_ok = SubscribeOk {
+                subscribe_id: VarInt(0),
+                expires: VarInt(0),
+                group_order: GroupOrder::Publisher,
+                content_exists: false,
+                largest_group_id: None,
+                largest_object_id: None,
+                parameters: Vec::new(),
+            };
+            let mut server_bytes = bytes::BytesMut::new();
+            ControlMessage::ServerSetup(server_setup).encode(&mut server_bytes);
+            let mut ok_bytes = bytes::BytesMut::new();
+            ControlMessage::SubscribeOk(sub_ok).encode(&mut ok_bytes);
+
+            let written = Arc::new(Mutex::new(Vec::new()));
+            let conn = MockConnection {
+                read: VecDeque::from(vec![server_bytes.to_vec(), ok_bytes.to_vec()]),
+                written: written.clone(),
+            };
+
+            let mut sess = Session::new_client(conn, None).await.unwrap();
+
+            sess.subscribe(vec![bytes::Bytes::from_static(b"ns")], bytes::Bytes::from_static(b"track"))
+                .await
+                .unwrap();
+
+            assert!(matches!(sess.subscribes.get(&0), Some(SubscribeState::Active)));
+        });
+    }
+
+    #[test]
+    fn fetch_ok_updates_state() {
+        block_on(async {
+            let server_setup = ServerSetup {
+                selected_version: VarInt(1),
+                parameters: Vec::new(),
+            };
+            let fetch_ok = FetchOk {
+                subscribe_id: VarInt(0),
+                group_order: GroupOrder::Publisher,
+                end_of_track: false,
+                largest_group_id: VarInt(0),
+                largest_object_id: VarInt(0),
+                parameters: Vec::new(),
+            };
+            let mut server_bytes = bytes::BytesMut::new();
+            ControlMessage::ServerSetup(server_setup).encode(&mut server_bytes);
+            let mut ok_bytes = bytes::BytesMut::new();
+            ControlMessage::FetchOk(fetch_ok).encode(&mut ok_bytes);
+
+            let written = Arc::new(Mutex::new(Vec::new()));
+            let conn = MockConnection {
+                read: VecDeque::from(vec![server_bytes.to_vec(), ok_bytes.to_vec()]),
+                written: written.clone(),
+            };
+
+            let mut sess = Session::new_client(conn, None).await.unwrap();
+
+            sess.fetch(vec![bytes::Bytes::from_static(b"ns")], bytes::Bytes::from_static(b"track"))
+                .await
+                .unwrap();
+
+            assert!(matches!(sess.fetches.get(&0), Some(FetchState::Active)));
         });
     }
 }


### PR DESCRIPTION
## Summary
- track subscription and fetch state in `Session`
- implement unsubscribe, subscribe_announces, fetch, fetch_cancel APIs
- add wasm-friendly dummy connection for tests
- expand tests for new subscribe/fetch flows

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6857a281ea5c8329a65b524405af11d3