### PR TITLE
Fix default priorities

### DIFF
--- a/packages/moqtail-core/src/relay.rs
+++ b/packages/moqtail-core/src/relay.rs
@@ -61,10 +61,13 @@ impl Relay {
         if let Some(subs) = self.subscriptions.get(track) {
             for s in subs {
                 if let Some(list) = self.subscribers.get_mut(s) {
+                    // Use a middle value (128) as the default publisher
+                    // priority so that individual objects can raise or
+                    // lower their priority if needed.
                     list.push(Object {
                         track_alias: VarInt(*s as u64),
                         id,
-                        publisher_priority: 0,
+                        publisher_priority: 128,
                         payload: payload.clone(),
                     });
                 }

--- a/packages/moqtail-core/src/session.rs
+++ b/packages/moqtail-core/src/session.rs
@@ -104,7 +104,9 @@ impl<T: MoqConnection> Session<T> {
             track_alias: VarInt(sub_id),
             track_namespace: namespace,
             track_name: name,
-            subscriber_priority: 0,
+            // Use the middle of the range (128) as the default subscriber
+            // priority so users can increase or decrease it as needed.
+            subscriber_priority: 128,
             group_order: GroupOrder::Publisher,
             filter_type: SubscribeFilter::LatestObject,
             start_group: None,


### PR DESCRIPTION
## Summary
- default subscriber priority to 128 when issuing `SUBSCRIBE`
- default publisher priority to 128 when relaying objects

## Testing
- `cargo test -p moqtail-core`
- `cargo test -p moqtail-wasm`


------
https://chatgpt.com/codex/tasks/task_e_6857a458e88883298f9010683b7a13ca