### PR TITLE
Add session close helpers and GOAWAY handling

### DIFF
--- a/packages/moqtail-core/src/session.rs
+++ b/packages/moqtail-core/src/session.rs
@@ -1,8 +1,7 @@
 use crate::coding::{Decode, Encode, VarInt};
 use crate::message::{
-    ClientSetup, ControlMessage, Fetch, FetchCancel, FetchError, FetchOk, FetchType,
-    ServerSetup,
-    Subscribe, SubscribeAnnounces, SubscribeAnnouncesError, SubscribeAnnouncesOk,
+    ClientSetup, ControlMessage, Fetch, FetchCancel, FetchError, FetchOk, FetchType, GoAway,
+    ServerSetup, Subscribe, SubscribeAnnounces, SubscribeAnnouncesError, SubscribeAnnouncesOk,
     SubscribeError, SubscribeOk, Unsubscribe,
 };
 use crate::model::*;
@@ -123,7 +122,9 @@ impl<T: MoqConnection> Session<T> {
         self.next_subscribe_id += 1;
 
         if self.subscribes.contains_key(&sub_id) {
-            return Err(std::io::Error::new(std::io::ErrorKind::Other, "duplicate subscribe id").into());
+            return Err(
+                std::io::Error::new(std::io::ErrorKind::Other, "duplicate subscribe id").into(),
+            );
         }
 
         let msg = Subscribe {
@@ -184,10 +185,7 @@ impl<T: MoqConnection> Session<T> {
         Ok(())
     }
 
-    pub async fn subscribe_announces(
-        &mut self,
-        namespace: TrackNamespace,
-    ) -> Result<(), T::Error> {
+    pub async fn subscribe_announces(&mut self, namespace: TrackNamespace) -> Result<(), T::Error> {
         let msg = SubscribeAnnounces {
             track_namespace_prefix: namespace,
             parameters: Vec::new(),
@@ -202,11 +200,9 @@ impl<T: MoqConnection> Session<T> {
 
         match ControlMessage::decode(&mut bytes) {
             Ok(ControlMessage::SubscribeAnnouncesOk(_)) => Ok(()),
-            Ok(ControlMessage::SubscribeAnnouncesError(e)) => Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                e.reason_phrase,
-            )
-            .into()),
+            Ok(ControlMessage::SubscribeAnnouncesError(e)) => {
+                Err(std::io::Error::new(std::io::ErrorKind::Other, e.reason_phrase).into())
+            }
             _ => Err(std::io::Error::new(std::io::ErrorKind::Other, "protocol error").into()),
         }
     }
@@ -220,7 +216,9 @@ impl<T: MoqConnection> Session<T> {
         self.next_subscribe_id += 1;
 
         if self.fetches.contains_key(&id) {
-            return Err(std::io::Error::new(std::io::ErrorKind::Other, "duplicate fetch id").into());
+            return Err(
+                std::io::Error::new(std::io::ErrorKind::Other, "duplicate fetch id").into(),
+            );
         }
 
         let msg = Fetch {
@@ -282,6 +280,13 @@ impl<T: MoqConnection> Session<T> {
                     // Only one bidirectional stream (the control stream) is used
                     // in the current draft. Receiving another is a protocol violation.
                     log::warn!("unexpected bidirectional stream received");
+                    self.conn
+                        .close(
+                            SessionCloseCode::ProtocolViolation.into(),
+                            "unexpected bidirectional stream",
+                        )
+                        .await?;
+                    break;
                 }
                 TransportEvent::UniStream(mut _s) => {
                     // Handling of data streams is out of scope for this example.
@@ -293,6 +298,20 @@ impl<T: MoqConnection> Session<T> {
             }
         }
         Ok(())
+    }
+
+    /// Send a GOAWAY control message to initiate session migration.
+    pub async fn send_goaway(&mut self, new_session_uri: String) -> Result<(), T::Error> {
+        let msg = GoAway { new_session_uri };
+        let mut buf = bytes::BytesMut::new();
+        ControlMessage::GoAway(msg).encode(&mut buf);
+        self.control_stream.write_all(&buf).await?;
+        Ok(())
+    }
+
+    /// Close the underlying connection with the given error code and reason.
+    pub async fn close(&mut self, code: SessionCloseCode, reason: &str) -> Result<(), T::Error> {
+        self.conn.close(code.into(), reason).await
     }
 
     // TODO: イベントをポーリングし、状態を更新する `run` ループを実装
@@ -326,6 +345,8 @@ pub trait MoqConnection {
     async fn poll_event(
         &mut self,
     ) -> Result<TransportEvent<Self::BiStream, Self::UniStream, Self::Datagram>, Self::Error>;
+
+    async fn close(&mut self, code: VarInt, reason: &str) -> Result<(), Self::Error>;
 }
 
 #[cfg(test)]
@@ -459,6 +480,10 @@ mod tests {
         {
             Ok(TransportEvent::ConnectionClosed)
         }
+
+        async fn close(&mut self, _code: VarInt, _reason: &str) -> Result<(), Self::Error> {
+            Ok(())
+        }
     }
 
     #[test]
@@ -524,11 +549,17 @@ mod tests {
 
             let mut sess = Session::new_client(conn, None).await.unwrap();
 
-            sess.subscribe(vec![bytes::Bytes::from_static(b"ns")], bytes::Bytes::from_static(b"track"))
-                .await
-                .unwrap();
+            sess.subscribe(
+                vec![bytes::Bytes::from_static(b"ns")],
+                bytes::Bytes::from_static(b"track"),
+            )
+            .await
+            .unwrap();
 
-            assert!(matches!(sess.subscribes.get(&0), Some(SubscribeState::Active)));
+            assert!(matches!(
+                sess.subscribes.get(&0),
+                Some(SubscribeState::Active)
+            ));
         });
     }
 
@@ -560,11 +591,45 @@ mod tests {
 
             let mut sess = Session::new_client(conn, None).await.unwrap();
 
-            sess.fetch(vec![bytes::Bytes::from_static(b"ns")], bytes::Bytes::from_static(b"track"))
-                .await
-                .unwrap();
+            sess.fetch(
+                vec![bytes::Bytes::from_static(b"ns")],
+                bytes::Bytes::from_static(b"track"),
+            )
+            .await
+            .unwrap();
 
             assert!(matches!(sess.fetches.get(&0), Some(FetchState::Active)));
+        });
+    }
+
+    #[test]
+    fn goaway_message_sent() {
+        block_on(async {
+            let server_setup = ServerSetup {
+                selected_version: VarInt(1),
+                parameters: Vec::new(),
+            };
+            let mut server_bytes = bytes::BytesMut::new();
+            ControlMessage::ServerSetup(server_setup).encode(&mut server_bytes);
+
+            let written = Arc::new(Mutex::new(Vec::new()));
+            let conn = MockConnection {
+                read: VecDeque::from(vec![server_bytes.to_vec()]),
+                written: written.clone(),
+            };
+
+            let mut sess = Session::new_client(conn, None).await.unwrap();
+            sess.send_goaway("moq://new".to_string()).await.unwrap();
+
+            let data = written.lock().unwrap();
+            let mut bytes = bytes::Bytes::from(data.clone());
+            // first message is client setup, second is GOAWAY
+            let _setup = ControlMessage::decode(&mut bytes).unwrap();
+            let goaway = ControlMessage::decode(&mut bytes).unwrap();
+            match goaway {
+                ControlMessage::GoAway(g) => assert_eq!(g.new_session_uri, "moq://new"),
+                _ => panic!("expected GOAWAY"),
+            }
         });
     }
 }

--- a/packages/moqtail-wasm/src/lib.rs
+++ b/packages/moqtail-wasm/src/lib.rs
@@ -1,12 +1,12 @@
-use moqtail_core::session::{MoqTransport, MoqConnection, TransportEvent};
 use async_trait::async_trait;
+use console_error_panic_hook;
+use js_sys::Uint8Array;
+use moqtail_core::session::{MoqConnection, MoqTransport, TransportEvent};
+use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 use wasm_streams::readable::{IntoAsyncRead, ReadableStream};
 use wasm_streams::writable::{IntoAsyncWrite, WritableStream};
-use console_error_panic_hook;
-use wasm_bindgen::JsCast;
-use js_sys::Uint8Array;
 
 #[derive(Debug, thiserror::Error)]
 pub enum WasmError {
@@ -25,7 +25,9 @@ impl From<JsValue> for WasmError {
 pub struct WasmTransport;
 
 impl WasmTransport {
-    pub fn new() -> Self { Self }
+    pub fn new() -> Self {
+        Self
+    }
 }
 
 pub struct WasmConnection {
@@ -98,7 +100,10 @@ impl MoqConnection for WasmConnection {
 
         let rs = ReadableStream::from_raw(bi_stream.readable().into()).into_async_read();
         let ws = WritableStream::from_raw(bi_stream.writable().into()).into_async_write();
-        Ok(WasmBiStream { reader: rs, writer: ws })
+        Ok(WasmBiStream {
+            reader: rs,
+            writer: ws,
+        })
     }
 
     async fn open_uni(&mut self) -> Result<Self::UniStream, Self::Error> {
@@ -116,12 +121,29 @@ impl MoqConnection for WasmConnection {
         Ok(())
     }
 
-    async fn poll_event(&mut self) -> Result<TransportEvent<Self::BiStream, Self::UniStream, Self::Datagram>, Self::Error> {
+    async fn poll_event(
+        &mut self,
+    ) -> Result<TransportEvent<Self::BiStream, Self::UniStream, Self::Datagram>, Self::Error> {
         // Wasmでのイベントポーリングは複雑。
         // `select`のような機能がないため、通常は複数のFutureを`race`するか、
         // `Stream`をマージして処理する。
         // ここでは概念を示すための未実装のプレースホルダー。
-        unimplemented!("Polling events in Wasm requires a more complex setup, likely merging multiple streams.");
+        unimplemented!(
+            "Polling events in Wasm requires a more complex setup, likely merging multiple streams."
+        );
+    }
+
+    async fn close(
+        &mut self,
+        code: moqtail_core::coding::VarInt,
+        reason: &str,
+    ) -> Result<(), Self::Error> {
+        let _ = code;
+        let _ = reason;
+        // `WebTransport::close()` currently doesn't allow specifying a close code
+        // without unstable APIs, so we call the basic variant.
+        self.transport.close();
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary
- support sending GOAWAY and closing a session
- expose connection close on the MoqConnection trait
- implement close for wasm connection
- handle unexpected extra bidirectional streams as protocol violations
- test GOAWAY behaviour

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6857a4e15c708329b7213a0d44c7ad5a