### PR TITLE
Improve relay handling

### DIFF
--- a/packages/moqtail-core/src/relay.rs
+++ b/packages/moqtail-core/src/relay.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::coding::VarInt;
-use crate::model::{FullTrackName, Object, ObjectId, TrackNamespace};
+use crate::model::{FullTrackName, Object, ObjectId, TrackAlias, TrackNamespace};
 
 /// Simple in-memory relay implementation.
 ///
@@ -24,6 +24,12 @@ pub struct Relay {
     subscribers: HashMap<usize, Vec<Object>>, // subscriber id -> received objects
     /// Authorized namespaces per subscriber
     authorized_subscribers: HashMap<usize, HashSet<TrackNamespace>>,
+    /// Authorized namespaces per publisher
+    authorized_publishers: HashMap<usize, HashSet<TrackNamespace>>,
+    /// Mapping of (publisher, track alias) to full track name
+    publisher_track_aliases: HashMap<(usize, TrackAlias), FullTrackName>,
+    /// Mapping of (subscriber, full track) to track alias used by that subscriber
+    subscriber_track_aliases: HashMap<(usize, FullTrackName), TrackAlias>,
     next_subscriber_id: usize,
     next_publisher_id: usize,
 }
@@ -39,6 +45,7 @@ impl Relay {
         let id = self.next_publisher_id;
         self.next_publisher_id += 1;
         self.publisher_namespaces.insert(id, HashSet::new());
+        self.authorized_publishers.insert(id, HashSet::new());
         id
     }
 
@@ -72,6 +79,7 @@ impl Relay {
         let id = self.next_subscriber_id;
         self.next_subscriber_id += 1;
         self.subscribers.insert(id, Vec::new());
+        self.authorized_subscribers.entry(id).or_default();
         id
     }
 
@@ -84,15 +92,52 @@ impl Relay {
             .insert(ns);
     }
 
-    /// Subscribe a subscriber to a full track name. Returns `true` if the subscriber
-    /// was authorized for the track's namespace and the subscription was stored.
-    pub fn subscribe(&mut self, subscriber: usize, track: FullTrackName) -> bool {
+    /// Authorize a publisher for a namespace.
+    pub fn authorize_publisher(&mut self, publisher: usize, ns: TrackNamespace) {
+        self.authorized_publishers
+            .entry(publisher)
+            .or_default()
+            .insert(ns);
+    }
+
+    /// Announce a track with a specific alias from a publisher.
+    /// Returns `true` if the publisher was authorized for the namespace.
+    pub fn announce_track(
+        &mut self,
+        publisher: usize,
+        alias: TrackAlias,
+        track: FullTrackName,
+    ) -> bool {
+        if let Some(allowed) = self.authorized_publishers.get(&publisher) {
+            if !allowed.contains(&track.namespace) {
+                return false;
+            }
+        }
+        self.announce(publisher, track.namespace.clone());
+        self.publisher_track_aliases
+            .insert((publisher, alias), track);
+        true
+    }
+
+    /// Subscribe a subscriber to a full track name with the alias used by the subscriber.
+    /// Returns `true` if authorized.
+    pub fn subscribe(
+        &mut self,
+        subscriber: usize,
+        track: FullTrackName,
+        alias: TrackAlias,
+    ) -> bool {
         if let Some(allowed) = self.authorized_subscribers.get(&subscriber) {
             if !allowed.contains(&track.namespace) {
                 return false;
             }
         }
-        self.subscriptions.entry(track).or_default().push(subscriber);
+        self.subscriptions
+            .entry(track.clone())
+            .or_default()
+            .push(subscriber);
+        self.subscriber_track_aliases
+            .insert((subscriber, track), alias);
         true
     }
 
@@ -114,27 +159,46 @@ impl Relay {
             .insert(publisher);
     }
 
-    /// Publish an object to the relay. The object is cached and forwarded to all
-    /// active subscribers for the object's track.
-    pub fn publish(&mut self, track: &FullTrackName, id: ObjectId, payload: bytes::Bytes) {
+    /// Publish an object directly to a track. This updates the cache and forwards
+    /// the object to all subscribers of the track using each subscriber's alias.
+    pub fn publish_to_track(
+        &mut self,
+        track: &FullTrackName,
+        id: ObjectId,
+        payload: bytes::Bytes,
+    ) {
         let key = (track.clone(), id);
-        // Update the cache with the newest object
         self.cache.insert(key.clone(), payload.clone());
 
         if let Some(subs) = self.subscriptions.get(track) {
             for s in subs {
                 if let Some(list) = self.subscribers.get_mut(s) {
-                    // Use a middle value (128) as the default publisher
-                    // priority so that individual objects can raise or
-                    // lower their priority if needed.
+                    let alias = self
+                        .subscriber_track_aliases
+                        .get(&(*s, track.clone()))
+                        .copied()
+                        .unwrap_or(VarInt(*s as u64));
                     list.push(Object {
-                        track_alias: VarInt(*s as u64),
+                        track_alias: alias,
                         id,
                         publisher_priority: 128,
                         payload: payload.clone(),
                     });
                 }
             }
+        }
+    }
+
+    /// Publish an object using the publisher's track alias.
+    pub fn publish_object(
+        &mut self,
+        publisher: usize,
+        alias: TrackAlias,
+        id: ObjectId,
+        payload: bytes::Bytes,
+    ) {
+        if let Some(track) = self.publisher_track_aliases.get(&(publisher, alias)).cloned() {
+            self.publish_to_track(&track, id, payload);
         }
     }
 
@@ -166,28 +230,29 @@ mod tests {
         let mut relay = Relay::new();
         let track = make_track();
         let publisher = relay.add_publisher();
-        relay.announce(publisher, track.namespace.clone());
+        relay.authorize_publisher(publisher, track.namespace.clone());
+        assert!(relay.announce_track(publisher, VarInt(0), track.clone()));
         let sub = relay.add_subscriber();
         relay.authorize_subscriber(sub, track.namespace.clone());
-        assert!(relay.subscribe(sub, track.clone()));
+        assert!(relay.subscribe(sub, track.clone(), VarInt(0)));
 
         let sub1 = relay.add_subscriber();
         relay.authorize_subscriber(sub1, track.namespace.clone());
         assert!(relay.should_subscribe_upstream(publisher, &track));
-        assert!(relay.subscribe(sub1, track.clone()));
+        assert!(relay.subscribe(sub1, track.clone(), VarInt(1)));
         relay.mark_upstream_subscribed(publisher, &track);
         assert!(!relay.should_subscribe_upstream(publisher, &track));
 
         let obj_id = ObjectId { group: VarInt(1), object: VarInt(1) };
-        relay.publish(&track, obj_id, bytes::Bytes::from_static(b"data"));
+        relay.publish_object(publisher, VarInt(0), obj_id, bytes::Bytes::from_static(b"data"));
 
         assert_eq!(relay.delivered(sub1).len(), 1);
         assert_eq!(relay.fetch(&track, &obj_id).unwrap(), bytes::Bytes::from_static(b"data"));
 
         let sub2 = relay.add_subscriber();
         relay.authorize_subscriber(sub2, track.namespace.clone());
-        assert!(relay.subscribe(sub2, track.clone()));
-        relay.publish(&track, ObjectId { group: VarInt(1), object: VarInt(2) }, bytes::Bytes::from_static(b"data2"));
+        assert!(relay.subscribe(sub2, track.clone(), VarInt(2)));
+        relay.publish_object(publisher, VarInt(0), ObjectId { group: VarInt(1), object: VarInt(2) }, bytes::Bytes::from_static(b"data2"));
 
         assert_eq!(relay.delivered(sub1).len(), 2);
         assert_eq!(relay.delivered(sub2).len(), 1);
@@ -198,11 +263,12 @@ mod tests {
         let mut relay = Relay::new();
         let track = make_track();
         let publisher = relay.add_publisher();
-        relay.announce(publisher, track.namespace.clone());
+        relay.authorize_publisher(publisher, track.namespace.clone());
+        assert!(relay.announce_track(publisher, VarInt(0), track.clone()));
 
         let obj_id = ObjectId { group: VarInt(1), object: VarInt(1) };
-        relay.publish(&track, obj_id, bytes::Bytes::from_static(b"a"));
-        relay.publish(&track, obj_id, bytes::Bytes::from_static(b"b"));
+        relay.publish_object(publisher, VarInt(0), obj_id, bytes::Bytes::from_static(b"a"));
+        relay.publish_object(publisher, VarInt(0), obj_id, bytes::Bytes::from_static(b"b"));
         assert_eq!(relay.fetch(&track, &obj_id).unwrap(), bytes::Bytes::from_static(b"b"));
     }
 
@@ -212,23 +278,45 @@ mod tests {
         let track = make_track();
         let pub1 = relay.add_publisher();
         let pub2 = relay.add_publisher();
-        relay.announce(pub1, track.namespace.clone());
-        relay.announce(pub2, track.namespace.clone());
+        relay.authorize_publisher(pub1, track.namespace.clone());
+        relay.authorize_publisher(pub2, track.namespace.clone());
+        assert!(relay.announce_track(pub1, VarInt(0), track.clone()));
+        assert!(relay.announce_track(pub2, VarInt(0), track.clone()));
 
         let sub = relay.add_subscriber();
         relay.authorize_subscriber(sub, track.namespace.clone());
-        assert!(relay.subscribe(sub, track.clone()));
+        assert!(relay.subscribe(sub, track.clone(), VarInt(0)));
 
         // mark upstream subscription only once per publisher
         relay.mark_upstream_subscribed(pub1, &track);
         relay.mark_upstream_subscribed(pub2, &track);
 
         let obj_id = ObjectId { group: VarInt(1), object: VarInt(1) };
-        relay.publish(&track, obj_id, bytes::Bytes::from_static(b"first"));
+        relay.publish_object(pub1, VarInt(0), obj_id, bytes::Bytes::from_static(b"first"));
         // duplicate object from another publisher should update cache
-        relay.publish(&track, obj_id, bytes::Bytes::from_static(b"second"));
+        relay.publish_object(pub2, VarInt(0), obj_id, bytes::Bytes::from_static(b"second"));
 
         assert_eq!(relay.fetch(&track, &obj_id).unwrap(), bytes::Bytes::from_static(b"second"));
         assert_eq!(relay.delivered(sub).len(), 2);
+    }
+
+    #[test]
+    fn subscriber_authorization() {
+        let mut relay = Relay::new();
+        let track = make_track();
+        let sub = relay.add_subscriber();
+        // Do not authorize subscriber
+        assert!(!relay.subscribe(sub, track.clone(), VarInt(0)));
+    }
+
+    #[test]
+    fn publisher_authorization() {
+        let mut relay = Relay::new();
+        let track = make_track();
+        let pub_id = relay.add_publisher();
+        // Publisher not authorized for namespace
+        assert!(!relay.announce_track(pub_id, VarInt(0), track.clone()));
+        relay.authorize_publisher(pub_id, track.namespace.clone());
+        assert!(relay.announce_track(pub_id, VarInt(0), track));
     }
 }


### PR DESCRIPTION
## Summary
- expand relay to track publisher and subscriber aliases
- support publisher/subscriber authorization
- add helper to publish using aliases
- update tests for new relay features

## Testing
- `cargo test -p moqtail-core --quiet`
- `cargo test -p moqtail-wasm --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6857a577bb788329988858d8aab872e3