### PR TITLE
Improve relay handling and add scheduler support

### DIFF
--- a/packages/moqtail-core/src/relay.rs
+++ b/packages/moqtail-core/src/relay.rs
@@ -1,14 +1,16 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::coding::VarInt;
-use crate::model::{FullTrackName, Object, ObjectId, TrackAlias, TrackNamespace};
+use crate::model::{
+    FullTrackName, GroupOrder, Object, ObjectId, TrackAlias, TrackNamespace,
+};
+use crate::scheduler::{DeliveryType, PriorityScheduler, QueueItem, SchedulableMeta};
 
 /// Simple in-memory relay implementation.
 ///
 /// The relay stores published objects in a cache and forwards them to
 /// subscribed receivers. This is a greatly simplified representation of the
 /// behaviour described in draft-ietf-moq-transport section 7.
-#[derive(Default)]
 pub struct Relay {
     /// Mapping of namespaces to publishers that announced them
     namespace_publishers: HashMap<TrackNamespace, HashSet<usize>>,
@@ -22,6 +24,10 @@ pub struct Relay {
     cache: HashMap<(FullTrackName, ObjectId), bytes::Bytes>,
     /// Delivered objects per subscriber (for testing)
     subscribers: HashMap<usize, Vec<Object>>, // subscriber id -> received objects
+    /// Pending delivery queue per subscriber ordered by scheduler
+    subscriber_queues: HashMap<usize, PriorityScheduler<Object>>,
+    /// Parameters associated with each subscription
+    subscription_params: HashMap<(usize, FullTrackName), SubscriptionParams>,
     /// Authorized namespaces per subscriber
     authorized_subscribers: HashMap<usize, HashSet<TrackNamespace>>,
     /// Authorized namespaces per publisher
@@ -32,6 +38,33 @@ pub struct Relay {
     subscriber_track_aliases: HashMap<(usize, FullTrackName), TrackAlias>,
     next_subscriber_id: usize,
     next_publisher_id: usize,
+}
+
+impl Default for Relay {
+    fn default() -> Self {
+        Self {
+            namespace_publishers: HashMap::new(),
+            publisher_namespaces: HashMap::new(),
+            subscriptions: HashMap::new(),
+            upstream_subscribed: HashMap::new(),
+            cache: HashMap::new(),
+            subscribers: HashMap::new(),
+            subscriber_queues: HashMap::new(),
+            subscription_params: HashMap::new(),
+            authorized_subscribers: HashMap::new(),
+            authorized_publishers: HashMap::new(),
+            publisher_track_aliases: HashMap::new(),
+            subscriber_track_aliases: HashMap::new(),
+            next_subscriber_id: 0,
+            next_publisher_id: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SubscriptionParams {
+    subscriber_priority: u8,
+    group_order: GroupOrder,
 }
 
 impl Relay {
@@ -79,6 +112,7 @@ impl Relay {
         let id = self.next_subscriber_id;
         self.next_subscriber_id += 1;
         self.subscribers.insert(id, Vec::new());
+        self.subscriber_queues.insert(id, PriorityScheduler::new());
         self.authorized_subscribers.entry(id).or_default();
         id
     }
@@ -126,6 +160,8 @@ impl Relay {
         subscriber: usize,
         track: FullTrackName,
         alias: TrackAlias,
+        subscriber_priority: u8,
+        group_order: GroupOrder,
     ) -> bool {
         if let Some(allowed) = self.authorized_subscribers.get(&subscriber) {
             if !allowed.contains(&track.namespace) {
@@ -137,7 +173,14 @@ impl Relay {
             .or_default()
             .push(subscriber);
         self.subscriber_track_aliases
-            .insert((subscriber, track), alias);
+            .insert((subscriber, track.clone()), alias);
+        self.subscription_params.insert(
+            (subscriber, track),
+            SubscriptionParams {
+                subscriber_priority,
+                group_order,
+            },
+        );
         true
     }
 
@@ -172,18 +215,49 @@ impl Relay {
 
         if let Some(subs) = self.subscriptions.get(track) {
             for s in subs {
-                if let Some(list) = self.subscribers.get_mut(s) {
+                if let Some(queue) = self.subscriber_queues.get_mut(s) {
                     let alias = self
                         .subscriber_track_aliases
                         .get(&(*s, track.clone()))
                         .copied()
                         .unwrap_or(VarInt(*s as u64));
-                    list.push(Object {
+                    let params = self
+                        .subscription_params
+                        .get(&(*s, track.clone()))
+                        .copied()
+                        .unwrap_or(SubscriptionParams {
+                            subscriber_priority: 128,
+                            group_order: GroupOrder::Publisher,
+                        });
+                    let obj = Object {
                         track_alias: alias,
                         id,
                         publisher_priority: 128,
                         payload: payload.clone(),
-                    });
+                    };
+                    let meta = SchedulableMeta {
+                        subscription_id: VarInt(*s as u64),
+                        track_alias: alias,
+                        group_id: id.group,
+                        subscriber_priority: params.subscriber_priority,
+                        publisher_priority: 128,
+                        group_order: params.group_order,
+                        delivery: DeliveryType::Datagram {
+                            object_id: id.object,
+                        },
+                    };
+                    queue.push(QueueItem { meta, payload: obj });
+                }
+            }
+        }
+    }
+
+    /// Flush pending deliveries according to each subscriber's scheduler.
+    pub fn flush(&mut self) {
+        for (id, queue) in self.subscriber_queues.iter_mut() {
+            while let Some(item) = queue.pop() {
+                if let Some(list) = self.subscribers.get_mut(id) {
+                    list.push(item.payload);
                 }
             }
         }
@@ -234,25 +308,50 @@ mod tests {
         assert!(relay.announce_track(publisher, VarInt(0), track.clone()));
         let sub = relay.add_subscriber();
         relay.authorize_subscriber(sub, track.namespace.clone());
-        assert!(relay.subscribe(sub, track.clone(), VarInt(0)));
+        assert!(relay.subscribe(
+            sub,
+            track.clone(),
+            VarInt(0),
+            128,
+            GroupOrder::Publisher
+        ));
 
         let sub1 = relay.add_subscriber();
         relay.authorize_subscriber(sub1, track.namespace.clone());
         assert!(relay.should_subscribe_upstream(publisher, &track));
-        assert!(relay.subscribe(sub1, track.clone(), VarInt(1)));
+        assert!(relay.subscribe(
+            sub1,
+            track.clone(),
+            VarInt(1),
+            128,
+            GroupOrder::Publisher
+        ));
         relay.mark_upstream_subscribed(publisher, &track);
         assert!(!relay.should_subscribe_upstream(publisher, &track));
 
         let obj_id = ObjectId { group: VarInt(1), object: VarInt(1) };
         relay.publish_object(publisher, VarInt(0), obj_id, bytes::Bytes::from_static(b"data"));
+        relay.flush();
 
         assert_eq!(relay.delivered(sub1).len(), 1);
         assert_eq!(relay.fetch(&track, &obj_id).unwrap(), bytes::Bytes::from_static(b"data"));
 
         let sub2 = relay.add_subscriber();
         relay.authorize_subscriber(sub2, track.namespace.clone());
-        assert!(relay.subscribe(sub2, track.clone(), VarInt(2)));
-        relay.publish_object(publisher, VarInt(0), ObjectId { group: VarInt(1), object: VarInt(2) }, bytes::Bytes::from_static(b"data2"));
+        assert!(relay.subscribe(
+            sub2,
+            track.clone(),
+            VarInt(2),
+            128,
+            GroupOrder::Publisher
+        ));
+        relay.publish_object(
+            publisher,
+            VarInt(0),
+            ObjectId { group: VarInt(1), object: VarInt(2) },
+            bytes::Bytes::from_static(b"data2")
+        );
+        relay.flush();
 
         assert_eq!(relay.delivered(sub1).len(), 2);
         assert_eq!(relay.delivered(sub2).len(), 1);
@@ -268,7 +367,9 @@ mod tests {
 
         let obj_id = ObjectId { group: VarInt(1), object: VarInt(1) };
         relay.publish_object(publisher, VarInt(0), obj_id, bytes::Bytes::from_static(b"a"));
+        relay.flush();
         relay.publish_object(publisher, VarInt(0), obj_id, bytes::Bytes::from_static(b"b"));
+        relay.flush();
         assert_eq!(relay.fetch(&track, &obj_id).unwrap(), bytes::Bytes::from_static(b"b"));
     }
 
@@ -285,7 +386,13 @@ mod tests {
 
         let sub = relay.add_subscriber();
         relay.authorize_subscriber(sub, track.namespace.clone());
-        assert!(relay.subscribe(sub, track.clone(), VarInt(0)));
+        assert!(relay.subscribe(
+            sub,
+            track.clone(),
+            VarInt(0),
+            128,
+            GroupOrder::Publisher
+        ));
 
         // mark upstream subscription only once per publisher
         relay.mark_upstream_subscribed(pub1, &track);
@@ -295,6 +402,7 @@ mod tests {
         relay.publish_object(pub1, VarInt(0), obj_id, bytes::Bytes::from_static(b"first"));
         // duplicate object from another publisher should update cache
         relay.publish_object(pub2, VarInt(0), obj_id, bytes::Bytes::from_static(b"second"));
+        relay.flush();
 
         assert_eq!(relay.fetch(&track, &obj_id).unwrap(), bytes::Bytes::from_static(b"second"));
         assert_eq!(relay.delivered(sub).len(), 2);
@@ -306,7 +414,7 @@ mod tests {
         let track = make_track();
         let sub = relay.add_subscriber();
         // Do not authorize subscriber
-        assert!(!relay.subscribe(sub, track.clone(), VarInt(0)));
+        assert!(!relay.subscribe(sub, track.clone(), VarInt(0), 0, GroupOrder::Publisher));
     }
 
     #[test]
@@ -318,5 +426,43 @@ mod tests {
         assert!(!relay.announce_track(pub_id, VarInt(0), track.clone()));
         relay.authorize_publisher(pub_id, track.namespace.clone());
         assert!(relay.announce_track(pub_id, VarInt(0), track));
+    }
+
+    #[test]
+    fn scheduler_respects_group_order() {
+        let mut relay = Relay::new();
+        let track = make_track();
+        let pub_id = relay.add_publisher();
+        relay.authorize_publisher(pub_id, track.namespace.clone());
+        assert!(relay.announce_track(pub_id, VarInt(0), track.clone()));
+
+        let sub = relay.add_subscriber();
+        relay.authorize_subscriber(sub, track.namespace.clone());
+        assert!(relay.subscribe(
+            sub,
+            track.clone(),
+            VarInt(0),
+            0,
+            GroupOrder::Ascending
+        ));
+
+        relay.publish_object(
+            pub_id,
+            VarInt(0),
+            ObjectId { group: VarInt(1), object: VarInt(0) },
+            bytes::Bytes::from_static(b"a"),
+        );
+        relay.publish_object(
+            pub_id,
+            VarInt(0),
+            ObjectId { group: VarInt(0), object: VarInt(0) },
+            bytes::Bytes::from_static(b"b"),
+        );
+        relay.flush();
+
+        let delivered = relay.delivered(sub);
+        assert_eq!(delivered.len(), 2);
+        assert_eq!(delivered[0].id.group, VarInt(0));
+        assert_eq!(delivered[1].id.group, VarInt(1));
     }
 }


### PR DESCRIPTION
## Summary
- enhance relay with per-subscriber scheduling
- store subscription parameters for priority and group order
- add `flush` method to release queued objects
- test scheduling behaviour

## Testing
- `cargo test --manifest-path packages/moqtail-core/Cargo.toml`
- `cargo check --manifest-path packages/moqtail-wasm/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6857a6b366cc83298ae74b0375a5cfe2