### PR TITLE
Add moqtail-loc package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
   "packages/moqtail-core",
   "packages/moqtail-wasm",
+  "packages/moqtail-loc",
 ]
 
 [workspace.package]

--- a/packages/moqtail-loc/Cargo.toml
+++ b/packages/moqtail-loc/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "moqtail-loc"
+edition.workspace = true
+version.workspace = true
+authors.workspace = true
+description = "LOC Streaming Format utilities"
+
+[dependencies]
+bytes = { workspace = true }
+thiserror = { workspace = true }
+moqtail-core = { path = "../moqtail-core" }

--- a/packages/moqtail-loc/src/lib.rs
+++ b/packages/moqtail-loc/src/lib.rs
@@ -1,0 +1,101 @@
+use bytes::Bytes;
+use moqtail_core::coding::VarInt;
+use moqtail_core::datastream::{ExtensionHeader, ExtensionHeaderValue};
+
+/// LOC Header Extension definitions as per the LOC Streaming Format specification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LocHeaderExtension {
+    /// Capture Timestamp in microseconds since Unix epoch.
+    CaptureTimestamp(u64),
+    /// Video decoder configuration extradata.
+    VideoConfig(Bytes),
+    /// Video Frame Marking flags encoded as a varint.
+    VideoFrameMarking(u32),
+    /// Audio Level encoded as a varint.
+    AudioLevel(u16),
+    /// Any extension that is not understood by this library.
+    Unknown(ExtensionHeader),
+}
+
+impl From<LocHeaderExtension> for ExtensionHeader {
+    fn from(ext: LocHeaderExtension) -> Self {
+        match ext {
+            LocHeaderExtension::CaptureTimestamp(ts) => ExtensionHeader {
+                id: VarInt(2),
+                value: ExtensionHeaderValue::VarInt(VarInt(ts as u64)),
+            },
+            LocHeaderExtension::VideoConfig(data) => ExtensionHeader {
+                id: VarInt(13),
+                value: ExtensionHeaderValue::Bytes(data),
+            },
+            LocHeaderExtension::VideoFrameMarking(v) => ExtensionHeader {
+                id: VarInt(4),
+                value: ExtensionHeaderValue::VarInt(VarInt(v as u64)),
+            },
+            LocHeaderExtension::AudioLevel(v) => ExtensionHeader {
+                id: VarInt(6),
+                value: ExtensionHeaderValue::VarInt(VarInt(v as u64)),
+            },
+            LocHeaderExtension::Unknown(h) => h,
+        }
+    }
+}
+
+impl From<ExtensionHeader> for LocHeaderExtension {
+    fn from(h: ExtensionHeader) -> Self {
+        match h.id.0 {
+            2 => match h.value {
+                ExtensionHeaderValue::VarInt(v) => LocHeaderExtension::CaptureTimestamp(v.0),
+                _ => LocHeaderExtension::Unknown(h),
+            },
+            13 => match h.value {
+                ExtensionHeaderValue::Bytes(b) => LocHeaderExtension::VideoConfig(b),
+                _ => LocHeaderExtension::Unknown(h),
+            },
+            4 => match h.value {
+                ExtensionHeaderValue::VarInt(v) => {
+                    LocHeaderExtension::VideoFrameMarking(v.0 as u32)
+                }
+                _ => LocHeaderExtension::Unknown(h),
+            },
+            6 => match h.value {
+                ExtensionHeaderValue::VarInt(v) => LocHeaderExtension::AudioLevel(v.0 as u16),
+                _ => LocHeaderExtension::Unknown(h),
+            },
+            _ => LocHeaderExtension::Unknown(h),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+
+    #[test]
+    fn conversion_roundtrip() {
+        let original = LocHeaderExtension::CaptureTimestamp(123);
+        let header: ExtensionHeader = original.clone().into();
+        assert_eq!(header.id, VarInt(2));
+        let decoded = LocHeaderExtension::from(header);
+        assert_eq!(decoded, original);
+
+        let original = LocHeaderExtension::VideoConfig(Bytes::from_static(b"abc"));
+        let header: ExtensionHeader = original.clone().into();
+        assert_eq!(header.id, VarInt(13));
+        let decoded = LocHeaderExtension::from(header);
+        assert_eq!(decoded, original);
+
+        let original = LocHeaderExtension::VideoFrameMarking(5);
+        let header: ExtensionHeader = original.clone().into();
+        assert_eq!(header.id, VarInt(4));
+        let decoded = LocHeaderExtension::from(header);
+        assert_eq!(decoded, original);
+
+        let original = LocHeaderExtension::AudioLevel(7);
+        let header: ExtensionHeader = original.clone().into();
+        assert_eq!(header.id, VarInt(6));
+        let decoded = LocHeaderExtension::from(header);
+        assert_eq!(decoded, original);
+    }
+}


### PR DESCRIPTION
## Summary
- add `moqtail-loc` crate implementing basic LOC header extensions
- expose conversions between LOC extensions and `moqtail-core` header types
- register the new crate in workspace

## Testing
- `cargo test --workspace --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_6857ae006690832986a0f2c429504098